### PR TITLE
Badges, coveralls, docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
 
 script:
   - docker-compose up -d
-  - ./gradlew -PallScalaVersions test reportScoverage checkScoverage
+  - ./gradlew -PallScalaVersions testScoverage reportScoverage checkScoverage
 
 after_success:
   - ./gradlew coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
 
 script:
   - docker-compose up -d
-  - ./gradlew -PallScalaVersions clean test reportScoverage checkScoverage
+  - ./gradlew -PallScalaVersions test reportScoverage checkScoverage
 
 after_success:
   - ./gradlew coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
 
 script:
   - docker-compose up -d
-  - ./gradlew -PallScalaVersions testScoverage reportScoverage checkScoverage
+  - ./gradlew -PallScalaVersions reportScoverage checkScoverage
 
 after_success:
   - ./gradlew coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,7 @@ cache:
 
 script:
   - docker-compose up -d
-  - ./gradlew clean test checkScoverage
-  - docker-compose down
+  - ./gradlew -PallScalaVersions clean test reportScoverage checkScoverage
+
+after_success:
+  - ./gradlew coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ jdk:
 services:
   - docker
 
+# skip the install step, we don't want to compile code again in this step
+# the default is gradle assemble task. ideally we probably want to just download
+# all dependencies in this step
+install: true
+
+# see https://docs.travis-ci.com/user/languages/java/#caching
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://travis-ci.org/Workday/warp-core.svg?branch=master)](https://travis-ci.org/Workday/warp-core)
 [![Coverage Status](https://coveralls.io/repos/github/Workday/warp-core/badge.svg?branch=master)](https://coveralls.io/github/Workday/warp-core?branch=master)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.11/badge.svg?subject=scala_2.11)](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.11)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.12/badge.svg?subject=scala_2.12)](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.12)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.11/badge.svg?subject=scala+2.11)](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.11)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.12/badge.svg?subject=scala+2.12)](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.12)
 
 WARP (Workday Automated Regression Platform) is a flexible, lightweight, (mostly) functional Scala framework for collecting performance metrics and conducting sound experimental benchmarking.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://travis-ci.org/Workday/warp-core.svg?branch=master)](https://travis-ci.org/Workday/warp-core)
 <img src="https://img.shields.io/coveralls/github/Workday/warp-core/master.svg?sanitize=true">
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.11)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.12)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.11/badge.svg?subject=scala_2.11)](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.11)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.12/badge.svg?subject=scala_2.12)](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.12)
 
 WARP (Workday Automated Regression Platform) is a flexible, lightweight, (mostly) functional Scala framework for collecting performance metrics and conducting sound experimental benchmarking.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # warp-core
 
 [![Build Status](https://travis-ci.org/Workday/warp-core.svg?branch=master)](https://travis-ci.org/Workday/warp-core)
-<img src="https://img.shields.io/coveralls/github/Workday/warp-core/master.svg?sanitize=true">
+[![Coverage Status](https://coveralls.io/repos/github/Workday/warp-core/badge.svg?branch=master)](https://coveralls.io/github/Workday/warp-core?branch=master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.11/badge.svg?subject=scala_2.11)](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.11)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.12/badge.svg?subject=scala_2.12)](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.12)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # warp-core
 
-<img src="https://img.shields.io/travis/Workday/warp-core.svg?sanitize=true">
+<img src="https://img.shields.io/travis/Workday/warp-core/master.svg?sanitize=true">
+<img src="https://img.shields.io/coveralls/github/Workday/warp-core/master.svg?sanitize=true">
 
 WARP (Workday Automated Regression Platform) is a flexible, lightweight, (mostly) functional Scala framework for collecting performance metrics and conducting sound experimental benchmarking.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # warp-core
 
+<img src="https://img.shields.io/travis/Workday/warp-core.svg?sanitize=true">
+
 WARP (Workday Automated Regression Platform) is a flexible, lightweight, (mostly) functional Scala framework for collecting performance metrics and conducting sound experimental benchmarking.
 
 WARP features a domain specific language for describing experimental designs (conducting repeated trials for different experimental groups). Our library allows users to wrap existing tests with layers of measurement collectors that write performance metrics to a relational database. We also allow users to create arbiters to express custom failure criteria and performance requirements. One arbiter included out of the box is the RobustPcaArbiter, which uses machine learning to detect when a test is deviating from expected behavior and signal an alert.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ The versions are defined in gradle.properties, however you can also override fro
 ```
 $ ./gradlew -PscalaVersions=2.11.8,2.12.6 test
 ```
+This plugin works by repeatedly invoking the gradle task graph with each different scala version specified.
+Without any version specified, gradle will use the defaultScalaVersion from gradle.properties. This means local IDE builds
+will use just one scala version. If you need to run with all configured scala versions, pass the project property `allScalaVersions`
+```
+$ ./gradlew -PallScalaVersions test
+```
+
 
 ## Versioning
 We use the `nebula.release` plugin to determine versions.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # warp-core
 
-<img src="https://img.shields.io/travis/Workday/warp-core/master.svg?sanitize=true">
+[![Build Status](https://travis-ci.org/Workday/warp-core.svg?branch=master)](https://travis-ci.org/Workday/warp-core)
 <img src="https://img.shields.io/coveralls/github/Workday/warp-core/master.svg?sanitize=true">
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.11)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.workday.warp/warp-core_2.12)
 
 WARP (Workday Automated Regression Platform) is a flexible, lightweight, (mostly) functional Scala framework for collecting performance metrics and conducting sound experimental benchmarking.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ or to just run unit tests, run the `unitTest` task.
 
 All port values and service version numbers are in `.env`.
 
+## Code Coverage Requirements
+
+We use scoverage and coveralls gradle plugins to track code coverage. We enforce that high coverage should be maintained. At time of
+writing, coverage must be at least 92% for a build to pass. If you want to test coveralls out on your fork, sign in to coveralls
+and get your repo token. Then you can generate the coverage reports and submit them to coveralls using
+```
+$ export COVERALLS_REPO_TOKEN=abcdefg
+$ ./gradlew clean reportScoverage coveralls
+```
+
 
 ## Publishing
 We use the `maven-publish` gradle plugin.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,26 @@ All port values and service version numbers are in `.env`.
 We use the `maven-publish` gradle plugin.
 https://docs.gradle.org/current/userguide/publishing_maven.html
 
-Artifacts can be published to sonatype using `./gradlew publish`.
-You'll need to configure your sonatype and signing credentials as project properties:
+Please use the included `publish.sh` for uploading artifacts. This script handles some subtle interaction between
+creating repo tags and scala multiversion plugin.
+
+Example usage:
+```
+./publish.sh snapshot minor local
+```
+
+Will increment minor version component and publish a snapshot (eg 2.3.0-SNAPSHOT) to local maven repo.
+
+To publish to sonatype, the invocation would be something like:
+```
+./publish.sh candidate minor sonatype
+```
+
+To publish to sonatype, you'll need to configure your sonatype and signing credentials as project properties:
+
+[create sonatype jira account](https://issues.sonatype.org/secure/Signup!default.jspa)
+
+[create pgp keys](https://central.sonatype.org/pages/working-with-pgp-signatures.html)
 ```
 signing.keyId=BEEF
 signing.password=abc123
@@ -41,7 +59,7 @@ signing.secretKeyRingFile=/full/path/to/secring.gpg
 sonatypeUsername=jean-luc.picard
 sonatypePassword=makeItSoNumberOne
 ```
-Artifacts can be published to local maven repo using `./gradlew publishToMavenLocal`. Signing is not required for local publish.
+Signing is not required for a local publish.
 
 ## Scala Multiversion
 We use [gradle-scala-multiversion-plugin](https://github.com/ADTRAN/gradle-scala-multiversion-plugin)
@@ -72,22 +90,15 @@ git push origin --tags
 There are 4 types of releases we support:
   - final
   - candidate (rc)
-  - devSnapshot includes some extra information in the version, including branch name and commit hash.
+  - devSnapshot (includes some extra information in the version, including branch name and commit hash)
   - snapshot
   
-Artifacts with type `snapshot` or `devSnapshot` are published to workday-unit repo, 
-while `final` and `candidate` artifacts are published to workday-release.
+Artifacts with type `snapshot` or `devSnapshot` are published to sonatype snapshots repo, 
+while `final` and `candidate` artifacts are published to sonatype releases repo.
 
-By default, the minor version number will be incremented based on the most recent tagged release. If you instead need to
-increment the major or patch version, use the property `release.scope`:
-```
-./gradlew <snapshot|devSnapshot|candidate|final> -Prelease.scope=patch
-```
-
-The version can also be overridden using the property `release.version` (please refrain from using this if possible):
-```
-./gradlew -Prelease.version=1.2.3 final
-```
+Please use the included `publish.sh` script for publishing, as that script handles interaction between creating repo tags
+and scala multiversion. We don't want to create multiple tags during a release process and incorrectly publish some artifacts
+under the wrong version.
 
 
 ## Dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ allprojects {
     apply plugin: 'nebula.release'
     apply plugin: "nebula.maven-resolved-dependencies"
     apply plugin: "org.scoverage"
+    apply plugin: "com.github.kt3k.coveralls"
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
 }
@@ -33,6 +34,7 @@ buildscript {
         classpath "com.netflix.nebula:nebula-publishing-plugin:${versions.nebulaPublish}"
         classpath "org.ajoberstar:grgit:${versions.gradleGit}"
         classpath "org.github.ngbinh.scalastyle:gradle-scalastyle-plugin${project.scalaSuffix}:${versions.scalaStyle}"
+        classpath "org.kt3k.gradle.plugin:coveralls-gradle-plugin:${versions.coveralls}"
         classpath "org.scoverage:gradle-scoverage:${versions.gradleScoverage}"
     }
 }
@@ -217,6 +219,10 @@ checkScoverage {
     minimumRate = 0.92
 }
 
+coveralls {
+    coberturaReportPath = "${buildDir}/reports/scoverage/cobertura.xml"
+}
+
 /**
  * @return true iff we are building a maven snapshot or a devSnapshot.
  */
@@ -274,6 +280,7 @@ publishing {
 }
 
 signing {
+    // only require signing for non-snapshot versions being published to maven central
     required {
         !isSnapshot(version.toString()) && gradle.taskGraph.hasTask("publish")
     }

--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,16 @@ test {
     }
 }
 
+testScoverage {
+    minHeapSize = "500m"
+    maxHeapSize = "8g"
+
+    testLogging {
+        events 'started', 'passed'
+        showStandardStreams = true
+    }
+}
+
 task deleteSchema(type: JavaExec, dependsOn: compileTestScala) {
     description = "deletes the db schema prior to running tests"
     main = "com.workday.warp.persistence.DropCoreSchema"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # scala cross compilation
 # by default, gradle invocations will use only this version. useful for ide invocations.
-defaultScalaVersions = 2.12.6
+defaultScalaVersions=2.12.6
 # if we need to cross-compile and rerun the entire task graph (like in a ci build or publish), run with -PallScalaVersions
 # see https://github.com/ADTRAN/gradle-scala-multiversion-plugin#examples
 scalaVersions=2.11.8,2.12.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,11 @@
-// scala cross compilation
+# scala cross compilation
+# by default, gradle invocations will use only this version. useful for ide invocations.
+defaultScalaVersions = 2.12.6
+# if we need to cross-compile and rerun the entire task graph (like in a ci build or publish), run with -PallScalaVersions
+# see https://github.com/ADTRAN/gradle-scala-multiversion-plugin#examples
 scalaVersions=2.11.8,2.12.6
 
-// during releases, we only want to create 1 repo tag. 
-// note that devSnapshot and snapshot tasks won't create repo tags
-// see https://github.com/ADTRAN/gradle-scala-multiversion-plugin#advanced-configuration
+# during releases, we only want to create 1 repo tag.
+# note that devSnapshot and snapshot tasks won't create repo tags
+# see https://github.com/ADTRAN/gradle-scala-multiversion-plugin#advanced-configuration
 runOnceTasks=clean,candidate,final,release

--- a/publish.sh
+++ b/publish.sh
@@ -5,6 +5,9 @@ set -e
 #   release type must be one of { devSnapshot, snapshot, candidate, final }
 #   release scope must be one of { major, minor, patch }
 #   repository must be one of { local, sonatype }
+#
+# example: ./publish.sh snapshot minor local
+#   will increment minor version component and publish snapshots to local maven repository
 
 if [[ $# -ne 3 ]]
 then
@@ -42,11 +45,11 @@ then
   echo "creating repo tag for $RELEASE_TYPE release"
   ./gradlew -Prelease.scope=$RELEASE_SCOPE clean $RELEASE_TYPE
   echo "publishing $REPOSITORY artifacts for $RELEASE_SCOPE $RELEASE_TYPE release"
-  ./gradlew -Prelease.useLastTag=true $PUBLISH_TASK
+  ./gradlew -Prelease.useLastTag=true -PallScalaVersions $PUBLISH_TASK
 elif [[ $RELEASE_TYPE = 'devSnapshot' || $RELEASE_TYPE == 'snapshot' ]]
 then
   echo "publishing $REPOSITORY artifacts for $RELEASE_SCOPE $RELEASE_TYPE release. repo tag will not be created."
-  ./gradlew -Prelease.scope=$RELEASE_SCOPE clean $RELEASE_TYPE $PUBLISH_TASK
+  ./gradlew -Prelease.scope=$RELEASE_SCOPE -PallScalaVersions clean $RELEASE_TYPE $PUBLISH_TASK
 else
   echo "$RELEASE_TYPE is not a valid release type"
   exit 1

--- a/versionInfo.gradle
+++ b/versionInfo.gradle
@@ -44,6 +44,7 @@ project.ext.versions = [
     , commonsConfiguration: '1.9'
     , commonsIo: '2.4'
     , commonsLang3: '3.4'
+    , coveralls: '2.8.2'
     , dispatch: '0.13.0'
     , flyway: '5.1.1'
     , freemarker: '2.3.19'


### PR DESCRIPTION
- badges for build status, code coverage, and latest 2.11 and 2.12 maven central artifacts
- minor tweaks to travis to speed up the build. skip the `install` step since that compiles code. its intended to download dependencies, but default setting for a gradle project is to run `assemble` task. https://docs.travis-ci.com/user/customizing-the-build/#the-build-lifecycle. having the jars downloaded at this stage has some interactions with the build cache behavior that i dont fully understand yet. i managed to cut build time from 20-25 minutes down to around 12-13 minutes. 
- coveralls gradle plugin uploads scoverage reports to coveralls. the coveralls docs here are actually pretty confusing. note that we don't have to specify any repo token as a ci env var. the coveralls api is able to infer it in conjunction with travis. if you want to test this locally, you'll need to turn on coveralls for your fork, and get your repo token. then you can do:
```
$ export COVERALLS_REPO_TOKEN=fjdlksahs
$ ./gradlew clean reportScoverage coveralls
```
- also tweaked scala multiversion settings. by default, all tasks will run using the version specified in gradle.properties `defaultScalaVersion`. this is intended to avoid running tests multiple times in intellij. if you want to run with all the scala versions defined in gradle.properties, pass `-PallScalaVersions`. modified the publish script and travis.yml to reflect this