### PR TITLE
config tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ classes
 out
 public
 gh-pages-src/static/scaladoc/warp-core
+config

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: java
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 language: java
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache:
 
 script:
   - docker-compose up -d
-  - ./gradlew -PallScalaVersions reportScoverage checkScoverage
+  - ./gradlew -PallScalaVersions copyConfigTemplate reportScoverage checkScoverage
 
 after_success:
   - ./gradlew coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
 
 script:
   - docker-compose up -d
-  - ./gradlew -PallScalaVersions copyConfigTemplate reportScoverage checkScoverage
+  - ./gradlew -PallScalaVersions copyConfigTemplate reportScoverage checkScoverage --stacktrace
 
 after_success:
   - ./gradlew coveralls

--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,15 @@ scaladoc {
     destinationDir file("$rootDir/gh-pages-src/static/scaladoc/${project.name}")
 }
 
+task copyConfigTemplate(type: Copy) {
+    from "config-templates/warp.properties.template"
+    rename { String filename ->
+        filename - '.template'
+    }
+
+    into "config/"
+}
+
 task unitTest(type: Test) {
     useJUnit {
         excludeCategories 'com.workday.warp.common.category.IntegrationTest'

--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     scoverage "org.scoverage:scalac-scoverage-runtime_%%:${versions.scalacScoverage}"
 
     runtimeOnly "com.h2database:h2:${versions.h2}"
+    runtimeOnly "commons-beanutils:commons-beanutils:${versions.beanUtils}"
     runtimeOnly "mysql:mysql-connector-java:${versions.mysqlConnector}"
     runtimeOnly "org.tinylog:slf4j-binding:${versions.tinylogSlf4jBinding}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,10 @@ scaladoc {
     destinationDir file("$rootDir/gh-pages-src/static/scaladoc/${project.name}")
 }
 
+// copy config template into a usable place
+// note this task does not have any dependencies, and nothing depends on this task.
+// the expectation is this task will always be run in a ci environment,
+// and can be run once locally on a fresh checkout to create a starting config point
 task copyConfigTemplate(type: Copy) {
     from "config-templates/warp.properties.template"
     rename { String filename ->

--- a/config-templates/warp.properties.template
+++ b/config-templates/warp.properties.template
@@ -6,6 +6,8 @@ wd.warp.jdbc.url=jdbc:mysql://localhost:3307/warp_core?createDatabaseIfNotExist=
 wd.warp.jdbc.password=1234
 wd.warp.jdbc.user=root
 wd.warp.jdbc.driver=com.mysql.jdbc.Driver
+# TODO seems slower in travis than locally. investigate.
+wd.warp.jdbc.timeout=300
 wd.warp.migrate.schema=true
 
 wd.warp.log.level=info

--- a/config-templates/warp.properties.template
+++ b/config-templates/warp.properties.template
@@ -1,3 +1,6 @@
+# template config file used in ci builds
+# this file is copied into config directory
+# for local development, this template can be used as a starting point for more customized settings
 wd.warp.jdbc.url=jdbc:mysql://localhost:3307/warp_core?createDatabaseIfNotExist=true&zeroDateTimeBehavior=convertToNull&verifyServerCertificate=false&useSSL=true
 # make sure to use something more secure in production
 wd.warp.jdbc.password=1234

--- a/dependencies_2.11.lock
+++ b/dependencies_2.11.lock
@@ -1352,6 +1352,16 @@
                 "com.typesafe.slick:slick-hikaricp_2.11"
             ]
         },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "requested": "1.9.3"
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
         "commons-io:commons-io": {
             "locked": "2.6",
             "requested": "2.6"
@@ -1359,6 +1369,7 @@
         "commons-logging:commons-logging": {
             "locked": "1.2",
             "transitive": [
+                "commons-beanutils:commons-beanutils",
                 "org.apache.commons:commons-configuration2"
             ]
         },
@@ -2440,6 +2451,16 @@
                 "com.typesafe.slick:slick-hikaricp_2.11"
             ]
         },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "requested": "1.9.3"
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
         "commons-io:commons-io": {
             "locked": "2.6",
             "requested": "2.6"
@@ -2447,6 +2468,7 @@
         "commons-logging:commons-logging": {
             "locked": "1.2",
             "transitive": [
+                "commons-beanutils:commons-beanutils",
                 "org.apache.commons:commons-configuration2"
             ]
         },
@@ -4630,6 +4652,16 @@
                 "com.typesafe.slick:slick-hikaricp_2.11"
             ]
         },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "requested": "1.9.3"
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
         "commons-io:commons-io": {
             "locked": "2.6",
             "requested": "2.6"
@@ -4637,6 +4669,7 @@
         "commons-logging:commons-logging": {
             "locked": "1.2",
             "transitive": [
+                "commons-beanutils:commons-beanutils",
                 "org.apache.commons:commons-configuration2"
             ]
         },

--- a/dependencies_2.12.lock
+++ b/dependencies_2.12.lock
@@ -1343,6 +1343,16 @@
                 "com.typesafe.slick:slick-hikaricp_2.12"
             ]
         },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "requested": "1.9.3"
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
         "commons-io:commons-io": {
             "locked": "2.6",
             "requested": "2.6"
@@ -1350,6 +1360,7 @@
         "commons-logging:commons-logging": {
             "locked": "1.2",
             "transitive": [
+                "commons-beanutils:commons-beanutils",
                 "org.apache.commons:commons-configuration2"
             ]
         },
@@ -2421,6 +2432,16 @@
                 "com.typesafe.slick:slick-hikaricp_2.12"
             ]
         },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "requested": "1.9.3"
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
         "commons-io:commons-io": {
             "locked": "2.6",
             "requested": "2.6"
@@ -2428,6 +2449,7 @@
         "commons-logging:commons-logging": {
             "locked": "1.2",
             "transitive": [
+                "commons-beanutils:commons-beanutils",
                 "org.apache.commons:commons-configuration2"
             ]
         },
@@ -4591,6 +4613,16 @@
                 "com.typesafe.slick:slick-hikaricp_2.12"
             ]
         },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "requested": "1.9.3"
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
         "commons-io:commons-io": {
             "locked": "2.6",
             "requested": "2.6"
@@ -4598,6 +4630,7 @@
         "commons-logging:commons-logging": {
             "locked": "1.2",
             "transitive": [
+                "commons-beanutils:commons-beanutils",
                 "org.apache.commons:commons-configuration2"
             ]
         },

--- a/scalastyle.xml
+++ b/scalastyle.xml
@@ -149,7 +149,7 @@
  </check>
  <check customId="two.spaces" enabled="true" class="org.scalastyle.file.RegexChecker" level="error">
   <parameters>
-   <parameter name="regex">[^\s]  [^\s]</parameter>
+   <parameter name="regex">[^\s/]  [^\s]</parameter>
    <parameter name="line">false</parameter>
   </parameters>
   <customMessage>tokens should not be separated by two spaces</customMessage>

--- a/src/main/scala/com/workday/warp/common/HasCoreWarpProperties.scala
+++ b/src/main/scala/com/workday/warp/common/HasCoreWarpProperties.scala
@@ -434,32 +434,6 @@ trait HasCoreWarpProperties extends WarpPropertyLike {
   )
 
   /**
-    * Whether anomaly detection provided by lambda function is enabled.
-    *
-    * Required: Yes
-    * Default Value: false
-    */
-  val WARP_LAMBDA_ARBITER_ENABLED: PropertyEntry = PropertyEntry("wd.warp.lambda.arbiter.enabled", isRequired = true, "false")
-
-  /**
-    * Fully qualified URL for anomaly detection lambda function.
-    *
-    * Required: Yes
-    * Default Value: https://nsd0jwpj65.execute-api.us-west-1.amazonaws.com/prod/anomaly_detection
-    */
-  val WARP_LAMBDA_ARBITER_URL: PropertyEntry = PropertyEntry(
-    "wd.warp.lambda.arbiter.url", isRequired = true, "https://nsd0jwpj65.execute-api.us-west-1.amazonaws.com/prod/anomaly_detection"
-  )
-
-  /**
-    * API key for the API that invokes the anomaly detection lambda function
-    *
-    * Required: Yes
-    * Default Value: None
-    */
-  val WARP_LAMBDA_ARBITER_API_KEY: PropertyEntry = PropertyEntry("wd.warp.lambda.arbiter.api.key", isRequired = true)
-
-  /**
     * Threshold used by the percentile (gaussian distribution z-score) arbiter.
     *
     * Required: No

--- a/src/main/scala/com/workday/warp/common/HasCoreWarpProperties.scala
+++ b/src/main/scala/com/workday/warp/common/HasCoreWarpProperties.scala
@@ -56,6 +56,16 @@ trait HasCoreWarpProperties extends WarpPropertyLike {
   val WARP_DATABASE_DRIVER: PropertyEntry = PropertyEntry("wd.warp.jdbc.driver", isRequired = true, "org.h2.Driver")
 
   /**
+    * Timeout for DB queries in seconds.
+    *
+    * We'll await slick futures for this duration.
+    *
+    * Required: Yes
+    * Default Value: 90
+    */
+  val WARP_DATABASE_TIMEOUT: PropertyEntry = PropertyEntry("wd.warp.jdbc.timeout", isRequired = true, "90")
+
+  /**
     * Whether or not we should apply flyway schema migrations.
     *
     * This should be disabled in the warp pipelines, where we want to manually run the schema migration jobs.

--- a/src/main/scala/com/workday/warp/common/WarpPropertyManager.scala
+++ b/src/main/scala/com/workday/warp/common/WarpPropertyManager.scala
@@ -246,7 +246,7 @@ object WarpPropertyManager {
    * 3. Finally, look for a warp.properties file in the users home .warp directory (i.e. /home/teamcity/.warp)
    */
   def computeConfigDirectory: String = {
-    val propertyFile: File = new File(s"./config/${this.WARP_PROPERTIES}")
+    val propertyFile: File = new File(s"config/${this.WARP_PROPERTIES}")
 
     // check the jvm system property
     if (this.systemProps.contains(this.WARP_CONFIG_DIRECTORY_PROPERTY)) {

--- a/src/main/scala/com/workday/warp/common/WarpPropertyManager.scala
+++ b/src/main/scala/com/workday/warp/common/WarpPropertyManager.scala
@@ -44,6 +44,8 @@ object WarpPropertyManager {
   val propertyFile: String = computePropertyFile
 
   // load the configuration file
+  // note that if the file does not exist, we log a warning and continue execution with an empty property set.
+  // if there is an unrecoverable exception from configuration library, we'll throw that exception
   val configuration: PropertiesConfiguration = Try(new Configurations().properties(propertyFile)).recoverWith {
     case _: ConfigurationException if !new File(propertyFile).exists() =>
       Logger.warn(s"$propertyFile does not exist!" +
@@ -54,7 +56,7 @@ object WarpPropertyManager {
     case exception: Exception =>
       Logger.error(exception, s"Error loading WARP Configuration file: $propertyFile \n\n")
       Failure(exception)
-  }.getOrElse(new PropertiesConfiguration)
+  }.get
 
   // use di to see which property set we are working with
   val propertyEntries: Seq[PropertyEntry] = WarpGuicer.getProperty.values

--- a/src/main/scala/com/workday/warp/common/WarpPropertyManager.scala
+++ b/src/main/scala/com/workday/warp/common/WarpPropertyManager.scala
@@ -45,6 +45,7 @@ object WarpPropertyManager {
 
   // load the configuration file
   // note that if the file does not exist, we log a warning and continue execution with an empty property set.
+  // (all default property values will be used)
   // if there is an unrecoverable exception from configuration library, we'll throw that exception
   val configuration: PropertiesConfiguration = Try(new Configurations().properties(propertyFile)).recoverWith {
     case _: ConfigurationException if !new File(propertyFile).exists() =>

--- a/src/main/scala/com/workday/warp/common/WarpPropertyManager.scala
+++ b/src/main/scala/com/workday/warp/common/WarpPropertyManager.scala
@@ -47,8 +47,8 @@ object WarpPropertyManager {
   val configuration: PropertiesConfiguration = Try(new Configurations().properties(propertyFile)).recoverWith {
     case _: ConfigurationException if !new File(propertyFile).exists() =>
       Logger.warn(s"$propertyFile does not exist!" +
-      "\n    Be aware that if the property values you require have not been passed in as Java System properties" +
-      "\n    this program is very likely to fail when an unset required property is accessed.\n")
+        "\n    Be aware that if the property values you require have not been passed in as Java System properties" +
+        "\n    this program is very likely to fail when an unset required property is accessed.\n")
       // fall back on empty config
       Success(new PropertiesConfiguration)
     case exception: Exception =>
@@ -241,12 +241,12 @@ object WarpPropertyManager {
    *
    * 1. If wd.warp.config.directory Java system property is supplied in the TeamCity build configuration, look for
    * warp.properties file in that location.
-   * 2. If wd.warp.config.directory is not defined, check if warp.properties exists in the current working directory
-   * (i.e. /data/teamcity/buildAgent1140/work/{unique job identifier}/{module}/warp.properties).
+   * 2. If wd.warp.config.directory is not defined, check if ./config/warp.properties exists
+   * (i.e. /data/teamcity/buildAgent1140/work/{unique job identifier}/{module}/config/warp.properties).
    * 3. Finally, look for a warp.properties file in the users home .warp directory (i.e. /home/teamcity/.warp)
    */
   def computeConfigDirectory: String = {
-    val propertyFile: File = new File(this.WARP_PROPERTIES)
+    val propertyFile: File = new File(s"./config/${this.WARP_PROPERTIES}")
 
     // check the jvm system property
     if (this.systemProps.contains(this.WARP_CONFIG_DIRECTORY_PROPERTY)) {

--- a/src/main/scala/com/workday/warp/common/heaphistogram/HeapHistogramEntry.scala
+++ b/src/main/scala/com/workday/warp/common/heaphistogram/HeapHistogramEntry.scala
@@ -1,27 +1,12 @@
 package com.workday.warp.common.heaphistogram
 
-import javax.management.openmbean.CompositeData
-
 /**
  * Small container class for class usage in a heap histogram.
  *
  * Created by tomas.mccandless on 9/21/15.
  */
-class HeapHistogramEntry(val className: String, val numInstances: Long, val numBytes: Long) {
+class HeapHistogramEntry(val className: String, val numInstances: Long, val numBytes: Long)
 
-  /**
-   * Auxiliary constructor accepting a CompositeData object
-   *
-   * @param histogramEntryCD CompositeData to construct a HeapHistogramEntry from
-   */
-  def this(histogramEntryCD: CompositeData) = {
-    this(
-      histogramEntryCD.get("className").toString,
-      histogramEntryCD.get("numInstances").toString.toLong,
-      histogramEntryCD.get("numBytes").toString.toLong
-    )
-  }
-}
 
 // compare entries based on their number of instances
 object InstancesOrdering extends Ordering[HeapHistogramEntry] {

--- a/src/main/scala/com/workday/warp/persistence/Connection.scala
+++ b/src/main/scala/com/workday/warp/persistence/Connection.scala
@@ -149,7 +149,7 @@ trait Connection {
 
 object Connection {
 
-  val timeout: Duration = Duration(90, "seconds")
+  val timeout: Duration = Duration(WARP_DATABASE_TIMEOUT.value.toInt, "seconds")
 
   val driver: String = WARP_DATABASE_DRIVER.value
   val url: String = WARP_DATABASE_URL.value

--- a/src/test/scala/com/workday/warp/collectors/ResponseTimeCollectorSpec.scala
+++ b/src/test/scala/com/workday/warp/collectors/ResponseTimeCollectorSpec.scala
@@ -2,6 +2,7 @@ package com.workday.warp.collectors
 
 import com.workday.warp.common.category.UnitTest
 import com.workday.warp.common.spec.WarpJUnitSpec
+import com.workday.warp.persistence.Tables.RowTypeClasses.TestExecutionRowTypeClassObject
 import org.junit.Test
 import org.junit.experimental.categories.Category
 
@@ -21,5 +22,16 @@ class ResponseTimeCollectorSpec extends WarpJUnitSpec {
 
     controller.beginMeasurementCollection()
     controller.endMeasurementCollection()
+  }
+
+
+  @Test
+  @Category(Array(classOf[UnitTest]))
+  def stackTrace(): Unit = {
+    val collector: ResponseTimeCollector = new ResponseTimeCollector(this.getTestId)
+
+    collector.tryStartMeasurement(true)
+    Thread.sleep(50)
+    collector.tryStopMeasurement(None, true)
   }
 }

--- a/src/test/scala/com/workday/warp/collectors/traits/ContinuousMeasurementSpec.scala
+++ b/src/test/scala/com/workday/warp/collectors/traits/ContinuousMeasurementSpec.scala
@@ -1,0 +1,38 @@
+package com.workday.warp.collectors.traits
+
+import com.workday.warp.common.category.UnitTest
+import com.workday.warp.common.spec.WarpJUnitSpec
+import com.workday.warp.persistence.Tables.RowTypeClasses.TestExecutionRowTypeClassObject
+import org.junit.Test
+import org.junit.experimental.categories.Category
+
+/**
+  * Created by tomas.mccandless on 11/14/18.
+  */
+class ContinuousMeasurementSpec extends WarpJUnitSpec with ContinuousMeasurement {
+
+
+  class DummyCollector extends ContinuousMeasurement {
+    override val measurementIntervalMs: Int = 600
+
+    var count: Int = 0 // scalastyle:ignore
+
+    /**
+      * Collects a single sample of measurement. Invoked periodically throughout the duration of a warp test.
+      * Should be overridden to provide the actual implementation of measurement sampling.
+      */
+    override def collectMeasurement(): Unit = this.count += 1
+  }
+
+
+  @Test
+  @Category(Array(classOf[UnitTest]))
+  def continuous(): Unit = {
+    val collector: DummyCollector = new DummyCollector
+    collector.startMeasurement()
+    Thread.sleep(800)
+    collector.stopMeasurement(None)
+
+    collector.count should be (2)
+  }
+}

--- a/src/test/scala/com/workday/warp/collectors/traits/ContinuousMeasurementSpec.scala
+++ b/src/test/scala/com/workday/warp/collectors/traits/ContinuousMeasurementSpec.scala
@@ -9,7 +9,7 @@ import org.junit.experimental.categories.Category
 /**
   * Created by tomas.mccandless on 11/14/18.
   */
-class ContinuousMeasurementSpec extends WarpJUnitSpec with ContinuousMeasurement {
+class ContinuousMeasurementSpec extends WarpJUnitSpec {
 
 
   class DummyCollector extends ContinuousMeasurement {

--- a/versionInfo.gradle
+++ b/versionInfo.gradle
@@ -37,7 +37,8 @@ def gatlingVersion() {
 // don't include paren, and don't use the longer syntax like:
 //   compile group: 'com.h2database', name: 'h2', version: "${versions.h2}"
 project.ext.versions = [
-    checkstyle: '8.11'
+    beanUtils: '1.9.3'
+    , checkstyle: '8.11'
     , commonsConfiguration2: '2.4'
     , commonsIo: '2.6'
     , coveralls: '2.8.2'


### PR DESCRIPTION
- from some discussion with @mottati, we decided to look for warp.properties file in `./config` rather than the current working directory. we also decided to create a `config-templates` directory whose contents are copied into `./config` during a ci build
- this is to avoid inadvertently checking in modifications to the starter `warp.properties` file
- remove some unused properties
- we also avoid directly calling `PropertiesConfiguration.read`, which is only supposed to be used internally by apache configuration library