### PR TITLE
allow environment variable overrides for configuration.

### DIFF
--- a/src/main/scala/com/workday/warp/common/PropertyEntry.scala
+++ b/src/main/scala/com/workday/warp/common/PropertyEntry.scala
@@ -7,6 +7,7 @@ package com.workday.warp.common
   */
 case class PropertyEntry(propertyName: String, isRequired: Boolean, defaultValue: String) {
 
+  // used as a name for looking up a corresponding environment variable
   val envVarName: String = this.propertyName.map(_.toUpper).replace(".", "_")
 
   def this(propertyName: String, isRequired: Boolean) = this(propertyName, isRequired, None.orNull)

--- a/src/main/scala/com/workday/warp/common/PropertyEntry.scala
+++ b/src/main/scala/com/workday/warp/common/PropertyEntry.scala
@@ -7,6 +7,8 @@ package com.workday.warp.common
   */
 case class PropertyEntry(propertyName: String, isRequired: Boolean, defaultValue: String) {
 
+  val envVarName: String = this.propertyName.map(_.toUpper).replace(".", "_")
+
   def this(propertyName: String, isRequired: Boolean) = this(propertyName, isRequired, None.orNull)
   def this(propertyName: String) = this(propertyName, isRequired = false)
 

--- a/src/main/scala/com/workday/warp/common/WarpPropertyManager.scala
+++ b/src/main/scala/com/workday/warp/common/WarpPropertyManager.scala
@@ -174,15 +174,16 @@ object WarpPropertyManager {
 
 
   /**
-   * Computes a map containing the assigned values of each WarpProperty according to the following sources in order of
-   * decreasing precedence:
-   *
-   *   1: jvm system properties
-   *   2: properties from the warp configuration file (warp.properties)
-   *   3: default property values provided in the enum
-   *
-   * @return an immutable Map containing the values for each WarpProperty
-   */
+    * Computes a map containing the assigned values of each WarpProperty according to the following sources in order of
+    * decreasing precedence:
+    *
+    *   1: environment variables
+    *   2: jvm system properties
+    *   3: properties from the warp configuration file (warp.properties)
+    *   4: default property values provided in the enum
+    *
+    * @return an immutable [[Map]] containing the values for each WarpProperty
+    */
   def overlayProperties: Map[String, String] = {
     val properties: mutable.Map[String, String] = mutable.Map[String, String]()
 
@@ -204,6 +205,11 @@ object WarpPropertyManager {
 
       // if we find a system property override, add it to our map
       this.systemProps.get(key) foreach { value =>
+        properties += (key -> value)
+      }
+
+      // if we find an environment variable override, add it to our map
+      sys.env.get(entry.envVarName) foreach { value =>
         properties += (key -> value)
       }
     }

--- a/src/main/scala/com/workday/warp/common/spec/WarpJUnitSpec.scala
+++ b/src/main/scala/com/workday/warp/common/spec/WarpJUnitSpec.scala
@@ -3,7 +3,7 @@ package com.workday.warp.common.spec
 import com.workday.telemetron.spec.HasTelemetron
 import com.workday.warp.common.utils.TryMatchers
 import org.scalatest._
-import org.scalatest.junit.{AssertionsForJUnit, JUnitSuite}
+import org.scalatestplus.junit.{AssertionsForJUnit, JUnitSuite}
 
 /**
   * Base class for WARP framework tests written in scalatest.

--- a/src/test/scala/com/workday/telemetron/junit/SurroundOnceSpec.scala
+++ b/src/test/scala/com/workday/telemetron/junit/SurroundOnceSpec.scala
@@ -3,7 +3,7 @@ package com.workday.telemetron.junit
 import com.workday.telemetron.annotation.{AfterOnce, BeforeOnce, Schedule}
 import org.junit.{Rule, Test}
 import org.scalatest.Matchers
-import org.scalatest.junit.JUnitSuite
+import org.scalatestplus.junit.JUnitSuite
 
 /**
   * Created by vignesh.kalidas on 2/8/17.

--- a/src/test/scala/com/workday/warp/common/PropertyEntrySpec.scala
+++ b/src/test/scala/com/workday/warp/common/PropertyEntrySpec.scala
@@ -15,5 +15,6 @@ class PropertyEntrySpec extends WarpJUnitSpec {
   def constructor(): Unit = {
     new PropertyEntry("com.workday.warp.foo").propertyName should be ("com.workday.warp.foo")
     PropertyEntry("com.workday.warp.foo").propertyName should be ("com.workday.warp.foo")
+    PropertyEntry("com.workday.warp.foo").envVarName should be ("COM_WORKDAY_WARP_FOO")
   }
 }


### PR DESCRIPTION
- properties can be configured via environment variables whose names are obtained by capitalizing and replacing periods in the original property name
- eg `wd.warp.jdbc.url` can be set with env var `WD_WARP_JDBC_URL`
```
% export WD_WARP_JDBC_URL=abcd
% gw clean test
...
INFO:
    WARP Framework Version = '@version@', Configuration File = '/Users/tomnis/code/warp-core/config/warp.properties'
...
        wd.warp.jdbc.url=abcd
...
    Caused by: java.lang.RuntimeException: Driver com.mysql.jdbc.Driver claims to not accept jdbcUrl, abcd
...
BUILD FAILED in 1m 0s
```
- the purpose of this change is to make docker configuration much simpler