### PR TITLE
PropertyEntry cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,12 @@ sourceSets {
     }
 }
 
+import org.apache.tools.ant.filters.ReplaceTokens
+
+processResources {
+    filter(ReplaceTokens, tokens: ['version': project.version.toString()])
+}
+
 task sourcesJar(type: Jar) {
     classifier = 'sources'
     from sourceSets.main.allSource

--- a/src/main/scala/com/workday/warp/common/HasCoreWarpProperties.scala
+++ b/src/main/scala/com/workday/warp/common/HasCoreWarpProperties.scala
@@ -344,7 +344,7 @@ trait HasCoreWarpProperties extends WarpPropertyLike {
     *
     * When this is set to false, we'll treat the time series as stationary.
     */
-  val WARP_ANOMALY_USE_DIFF: PropertyEntry = PropertyEntry("wd.warp.anomaly.use.diff", isRequired = false, None.orNull)
+  val WARP_ANOMALY_USE_DIFF: PropertyEntry = PropertyEntry("wd.warp.anomaly.use.diff", isRequired = false)
 
   /**
     * Number of most recent measurements we'll consider when wd.warp.anomaly.double.rpca is true. Running double rpca
@@ -502,6 +502,4 @@ trait HasCoreWarpProperties extends WarpPropertyLike {
   val WARP_SLF4J_FLYWAY_LOG_LEVEL: PropertyEntry = PropertyEntry(
     "wd.warp.slf4j.flyway.log.level", isRequired = false, "INFO"
   )
-
-
 }

--- a/src/main/scala/com/workday/warp/common/PropertyEntry.scala
+++ b/src/main/scala/com/workday/warp/common/PropertyEntry.scala
@@ -5,20 +5,16 @@ package com.workday.warp.common
   *
   * Created by tomas.mccandless on 11/14/17.
   */
-case class PropertyEntry(propertyName: String, isRequired: Boolean, defaultValue: String) {
+case class PropertyEntry(propertyName: String, isRequired: Boolean = false, defaultValue: Option[String] = None) {
 
   // used as a name for looking up a corresponding environment variable
   val envVarName: String = this.propertyName.map(_.toUpper).replace(".", "_")
 
-  def this(propertyName: String, isRequired: Boolean) = this(propertyName, isRequired, None.orNull)
-  def this(propertyName: String) = this(propertyName, isRequired = false)
-
-
   /** @return normalized configured value of this entry. Use this to obtain configuration values at runtime. */
-  def value: String = this.normalize(this.rawValue)
+  lazy val value: String = this.normalize(this.rawValue)
 
   /** @return raw configured value of this entry. */
-  def rawValue: String = WarpPropertyManager.valueOf(this.propertyName, this.isRequired)
+  lazy val rawValue: String = WarpPropertyManager.valueOf(this.propertyName, this.isRequired)
 
   /**
     * Normalizes `rawPropertyValue` to conform to some expected value.
@@ -36,6 +32,7 @@ case class PropertyEntry(propertyName: String, isRequired: Boolean, defaultValue
 
 object PropertyEntry {
 
-  def apply(propertyName: String, isRequired: Boolean): PropertyEntry = PropertyEntry(propertyName, isRequired, None.orNull)
-  def apply(propertyName: String): PropertyEntry = PropertyEntry(propertyName, isRequired = false)
+  def apply(propertyName: String, isRequired: Boolean, defaultValue: String): PropertyEntry = {
+    PropertyEntry(propertyName, isRequired, Option(defaultValue))
+  }
 }

--- a/src/main/scala/com/workday/warp/common/WarpPropertyManager.scala
+++ b/src/main/scala/com/workday/warp/common/WarpPropertyManager.scala
@@ -137,7 +137,7 @@ object WarpPropertyManager {
 
     banner ++= "\nWarp Configuration Properties:"
 
-    this.propertyEntries.foreach { entry: PropertyEntry =>
+    this.propertyEntries.toList.sortBy(_.propertyName).map { entry: PropertyEntry =>
       val name: String = entry.propertyName
       // value is not required to be present just for this lookup
       val propertyValue: String = entry.normalize(this.valueOf(name, required = false))

--- a/src/main/scala/com/workday/warp/common/WarpPropertyManager.scala
+++ b/src/main/scala/com/workday/warp/common/WarpPropertyManager.scala
@@ -1,6 +1,6 @@
 package com.workday.warp.common
 
-import java.io.{File, FileNotFoundException, FileReader}
+import java.io.File
 import java.util.Properties
 
 import com.workday.warp.common.exception.WarpConfigurationException
@@ -137,12 +137,13 @@ object WarpPropertyManager {
 
     banner ++= "\nWarp Configuration Properties:"
 
-    this.propertyEntries.map(_.propertyName) foreach { propertyName =>
+    this.propertyEntries.foreach { entry: PropertyEntry =>
+      val name: String = entry.propertyName
       // value is not required to be present just for this lookup
-      val propertyValue: String = this.valueOf(propertyName, required = false)
+      val propertyValue: String = entry.normalize(this.valueOf(name, required = false))
       // don't print password literals
-      val redactedValue: String = redact(propertyName, propertyValue)
-      banner ++= s"\n    $propertyName=$redactedValue"
+      val redactedValue: String = redact(name, propertyValue)
+      banner ++= s"\n    $name=$redactedValue"
     }
 
     Logger.info(banner.toString)
@@ -190,8 +191,8 @@ object WarpPropertyManager {
 
     // add non-null default values
     this.propertyEntries foreach { entry : PropertyEntry =>
-      if (Option(entry.defaultValue).isDefined) {
-        properties += (entry.propertyName -> entry.defaultValue)
+      entry.defaultValue foreach { default: String =>
+        properties += (entry.propertyName -> default)
       }
     }
 

--- a/src/main/scala/com/workday/warp/common/utils/FutureUtils.scala
+++ b/src/main/scala/com/workday/warp/common/utils/FutureUtils.scala
@@ -28,7 +28,7 @@ object FutureUtils {
     *         not parseable as an integer
     */
   def threadpoolSize(threads: String): Int = {
-    val defaultThreads: Int = WARP_NUM_COLLECTOR_THREADS.defaultValue.toInt
+    val defaultThreads: Int = WARP_NUM_COLLECTOR_THREADS.value.toInt
 
     try {
       val numThreads = threads.toInt

--- a/src/main/scala/com/workday/warp/common/utils/Implicits.scala
+++ b/src/main/scala/com/workday/warp/common/utils/Implicits.scala
@@ -11,7 +11,7 @@ import com.workday.warp.common.utils.TypeAliases._
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 /**
   * Utility implicits.
@@ -317,6 +317,16 @@ object Implicits {
       }
 
       this.aTry transform (cleanup, cleanup)
+    }
+
+
+    /**
+      * Transforms this [[Try]] to an [[Either]].
+      * @return
+      */
+    def toEither: Either[Throwable, T] = aTry match {
+      case Success(value) => Right(value)
+      case Failure(err) => Left(err)
     }
   }
 }

--- a/src/main/scala/com/workday/warp/logger/WarpLogUtils.scala
+++ b/src/main/scala/com/workday/warp/logger/WarpLogUtils.scala
@@ -89,16 +89,22 @@ object WarpLogUtils {
     * uses [[Level.INFO]]
     *
     * @param level [[String]] to attempt to parse into a [[Level]].
-    * @param default [[String]] to attempt to parse if `level` is not valid.
+    * @param default [[Option[String]]] to attempt to parse if `level` is not valid.
     * @return a [[Level]] parsed from `level` or `default`, or [[Level.INFO]] if neither is valid.
     */
-  private[logger] def parseLevel(level: String, default: String): Level = {
+  private[logger] def parseLevel(level: String, default: Option[String]): Level = {
     Try { Level valueOf level.toUpperCase } match {
       case Success(logLevel: Level) =>
         logLevel
       case Failure(exception) =>
         Logger.error(exception, s"unable to parse $level as a valid logging level, using $default")
-        Try { Level valueOf default.toUpperCase } getOrElse Level.INFO
+
+        val maybeLevel: Option[Level] = for {
+          d <- default
+          l <- Try(Level.valueOf(d)).toOption
+        } yield l
+
+        maybeLevel getOrElse Level.INFO
     }
   }
 }

--- a/src/test/scala/com/workday/warp/common/utils/DecoratedTrySpec.scala
+++ b/src/test/scala/com/workday/warp/common/utils/DecoratedTrySpec.scala
@@ -6,7 +6,7 @@ import com.workday.warp.common.utils.Implicits.DecoratedTry
 import org.junit.Test
 import org.junit.experimental.categories.Category
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 /**
   * Created by tomas.mccandless on 10/24/16.
@@ -27,5 +27,16 @@ class DecoratedTrySpec extends WarpJUnitSpec {
     val aFailedTry: Try[_] = Try(throw new RuntimeException)
     aFailedTry == (aFailedTry andThen { n += 1 }) should be (true)
     n should be (2)
+  }
+
+
+
+  /** Checks that we can transform a [[Try]] to an [[Either]]. */
+  @Test
+  @Category(Array(classOf[UnitTest]))
+  def toEither(): Unit = {
+    Success(1 + 1).toEither should be (Right(2))
+    val msg: String = "something failed"
+    Failure(new RuntimeException(msg)).toEither.left.map(_.getMessage) should be (Left(msg))
   }
 }

--- a/src/test/scala/com/workday/warp/common/utils/FutureUtilsSpec.scala
+++ b/src/test/scala/com/workday/warp/common/utils/FutureUtilsSpec.scala
@@ -18,7 +18,7 @@ class FutureUtilsSpec extends WarpJUnitSpec {
   @Test
   @Category(Array(classOf[UnitTest]))
   def testParseThreadpoolSize(): Unit = {
-    val defaultThreads: Int = WARP_NUM_COLLECTOR_THREADS.defaultValue.toInt
+    val defaultThreads: Int = WARP_NUM_COLLECTOR_THREADS.value.toInt
 
     FutureUtils.threadpoolSize("16") shouldBe 16
     FutureUtils.threadpoolSize("32") shouldBe 32

--- a/src/test/scala/com/workday/warp/logger/WarpLogUtilsSpec.scala
+++ b/src/test/scala/com/workday/warp/logger/WarpLogUtilsSpec.scala
@@ -15,7 +15,8 @@ class WarpLogUtilsSpec extends WarpJUnitSpec {
   @Category(Array(classOf[UnitTest]))
   def parseLogLevel(): Unit = {
 
-    WarpLogUtils.parseLevel("NOT_VALID_LEVEL", "DEBUG") should be (Level.DEBUG)
-    WarpLogUtils.parseLevel("NOT_VALID_LEVEL", "ALSO_NOT_VALID_LEVEL") should be (Level.INFO)
+    WarpLogUtils.parseLevel("NOT_VALID_LEVEL", Option("DEBUG")) should be (Level.DEBUG)
+    WarpLogUtils.parseLevel("NOT_VALID_LEVEL", Option("ALSO_NOT_VALID_LEVEL")) should be (Level.INFO)
+    WarpLogUtils.parseLevel("NOT_VALID_LEVEL", None) should be (Level.INFO)
   }
 }


### PR DESCRIPTION
- fix a bug where WarpPropertyManager doesn't log normalized property values
- a bit of cleanup in PropertyEntry, remove redundant aux constructors