### PR TITLE
date() should return java.sql.Date

### DIFF
--- a/src/main/scala/com/workday/warp/persistence/mysql/HasWarpSlickDsl.scala
+++ b/src/main/scala/com/workday/warp/persistence/mysql/HasWarpSlickDsl.scala
@@ -1,6 +1,6 @@
 package com.workday.warp.persistence.mysql
 
-import java.sql.Timestamp
+import java.sql
 
 import slick.jdbc.MySQLProfile.api._
 import slick.lifted.{Rep, SimpleExpression}
@@ -13,12 +13,14 @@ trait HasWarpSlickDsl {
 
   /**
     * dsl class for string related operations.
+    *
     * @param str String to perform MySQL operations on
     */
   implicit class StringExtensions(str: Rep[String]) {
 
     /**
       * Correlates to MySQL's `REGEXP` operator
+      *
       * @param pattern regex pattern
       * @return whether or not the string matched
       */
@@ -33,6 +35,7 @@ trait HasWarpSlickDsl {
 
     /**
       * Correlates to "QUOTE()"
+      *
       * @return properly SQL formatted escape string
       */
     def quote(): Rep[String] = {
@@ -46,6 +49,7 @@ trait HasWarpSlickDsl {
 
     /**
       * Translates to YEAR(string) function
+      *
       * @return just the year in Int
       */
     def year(): Rep[Int] = {
@@ -59,23 +63,25 @@ trait HasWarpSlickDsl {
 
     /**
       * Translates to DATE(string) function
+      *
       * @return just the date in string
       */
-    def date(): Rep[String] = {
-      val expression = SimpleExpression.unary[String, String] { (str, queryBuilder) =>
+    def date(): Rep[sql.Date] = {
+      val expression = SimpleExpression.unary[String, sql.Date] { (str, queryBuilder) =>
         queryBuilder.sqlBuilder += " DATE ("
         queryBuilder.expr(str)
         queryBuilder.sqlBuilder += ")"
       }
       expression.apply(str)
     }
-}
+  }
 
   /**
     * dsl class for DateTime related operations
+    *
     * @param date sql DateTime to perform operations on
     */
-  implicit class DateExtensions(date: Rep[java.sql.Date]) {
+  implicit class DateExtensions(date: Rep[sql.Date]) {
 
     /**
       * UNIX_TIMESTAMP operation - seconds elapsed since 1970-01-01 00:00:00 UTC
@@ -84,7 +90,7 @@ trait HasWarpSlickDsl {
       * @return seconds in int
       */
     def unixTimestamp(): Rep[Long] = {
-      val expression = SimpleExpression.unary[java.sql.Date, Long] { (dateNode, queryBuilder) =>
+      val expression = SimpleExpression.unary[sql.Date, Long] { (dateNode, queryBuilder) =>
         queryBuilder.sqlBuilder += " UNIX_TIMESTAMP ("
         queryBuilder.expr(dateNode)
         queryBuilder.sqlBuilder += ")"
@@ -96,9 +102,10 @@ trait HasWarpSlickDsl {
 
   /**
     * dsl class for Timestamp related operations
+    *
     * @param timestamp sql Timestamp to perform operations on
     */
-  implicit class TimeStampExtensions(timestamp: Rep[Timestamp]) {
+  implicit class TimeStampExtensions(timestamp: Rep[sql.Timestamp]) {
 
     /**
       * Roughly translates to `[Timestamp] > Now() - Interval` MySQL syntax.
@@ -107,7 +114,7 @@ trait HasWarpSlickDsl {
       * @return whether or not given timestamp is between now and `interval` ago.
       */
     def isWithinPast(interval: String): Rep[Boolean] = {
-      val expression = SimpleExpression.unary[Timestamp, Boolean] { (timestamp, queryBuilder) =>
+      val expression = SimpleExpression.unary[sql.Timestamp, Boolean] { (timestamp, queryBuilder) =>
         queryBuilder.expr(timestamp)
         queryBuilder.sqlBuilder += " > Now() - Interval "
         queryBuilder.sqlBuilder += interval
@@ -117,10 +124,11 @@ trait HasWarpSlickDsl {
 
     /**
       * Translates to DATE() function
+      *
       * @return just date in "yyyy-MM-dd"
       */
-    def date(): Rep[String] = {
-      val expression = SimpleExpression.unary[Timestamp, String] { (timestamp, queryBuilder) =>
+    def date(): Rep[sql.Date] = {
+      val expression = SimpleExpression.unary[sql.Timestamp, sql.Date] { (timestamp, queryBuilder) =>
         queryBuilder.sqlBuilder += " DATE ("
         queryBuilder.expr(timestamp)
         queryBuilder.sqlBuilder += ")"
@@ -131,13 +139,13 @@ trait HasWarpSlickDsl {
     /**
       * UNIX_TIMESTAMP operation - seconds elapsed since 1970-01-01 00:00:00 UTC
       * Takes in a parameter of TimeStamp: equivalent to UNIX_TIMESTAMP(date)
-
+      *
       * TODO: DATE and DATETIME parameters
       *
       * @return seconds in int
       */
     def unixTimestamp(): Rep[Long] = {
-      val expression = SimpleExpression.unary[Timestamp, Long] { (timestamp, queryBuilder) =>
+      val expression = SimpleExpression.unary[sql.Timestamp, Long] { (timestamp, queryBuilder) =>
         queryBuilder.sqlBuilder += " UNIX_TIMESTAMP ("
         queryBuilder.expr(timestamp)
         queryBuilder.sqlBuilder += ")"
@@ -147,10 +155,11 @@ trait HasWarpSlickDsl {
 
     /**
       * Translates to YEAR(timestamp) function
+      *
       * @return just the year in Int
       */
     def year(): Rep[Int] = {
-      val expression = SimpleExpression.unary[Timestamp, Int] { (timestamp, queryBuilder) =>
+      val expression = SimpleExpression.unary[sql.Timestamp, Int] { (timestamp, queryBuilder) =>
         queryBuilder.sqlBuilder += " YEAR ("
         queryBuilder.expr(timestamp)
         queryBuilder.sqlBuilder += ")"
@@ -160,10 +169,11 @@ trait HasWarpSlickDsl {
 
     /**
       * Translates to SUBDATE(timestamp) function
+      *
       * @return just the date as string
       */
     def subdate(interval: String): Rep[String] = {
-      val expression = SimpleExpression.unary[Timestamp, String] { (timestamp, queryBuilder) =>
+      val expression = SimpleExpression.unary[sql.Timestamp, String] { (timestamp, queryBuilder) =>
         queryBuilder.sqlBuilder += " subdate("
         queryBuilder.expr(timestamp)
         queryBuilder.sqlBuilder += ", INTERVAL "
@@ -172,13 +182,14 @@ trait HasWarpSlickDsl {
       }
       expression.apply(timestamp)
     }
-}
+  }
 
 
   object TimeStampExtensions {
 
     /**
       * equivalent to NOW()
+      *
       * @return string of date and time
       */
     def now(): Rep[String] = {
@@ -189,6 +200,7 @@ trait HasWarpSlickDsl {
 
     /**
       * UNIX_TIMESTAMP operation - seconds elapsed since 1970-01-01 00:00:00 UTC
+      *
       * @return seconds in int
       */
     def unixTimestamp(): Rep[Long] = {
@@ -231,19 +243,19 @@ trait HasWarpSlickDsl {
       expression.apply(date, amount)
     }
   }
-}
 
   /**
     * dsl class for math related operation
     */
   object NumberExtension {
+
     /**
       * translates to Round(number, decimals)
+      *
       * @return number
       */
-
     def round(number: Rep[Double], decimal: Int): Rep[Double] = {
-    
+
       val expression = SimpleExpression.binary[Double, Int, Double] { (number, decimal, queryBuilder) =>
         queryBuilder.sqlBuilder += "ROUND ("
         queryBuilder.expr(number)
@@ -256,9 +268,9 @@ trait HasWarpSlickDsl {
 
     /**
       * translates to Round(number)
+      *
       * @return number
       */
-
     def round(number: Rep[Double]): Rep[Int] = {
 
       val expression = SimpleExpression.unary[Double, Int] { (number, queryBuilder) =>
@@ -269,5 +281,6 @@ trait HasWarpSlickDsl {
       expression.apply(number)
     }
   }
+}
 
 

--- a/src/test/scala/com/workday/warp/persistence/mysql/WarpSlickDslSpec.scala
+++ b/src/test/scala/com/workday/warp/persistence/mysql/WarpSlickDslSpec.scala
@@ -2,13 +2,13 @@ package com.workday.warp.persistence.mysql
 
 
 import java.sql
-import java.util.{Calendar, TimeZone, Date => JUDate}
-import java.time._
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
-import java.time.format.DateTimeFormatter
 import java.text.DecimalFormat
+import java.time._
+import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
+import java.util.{Calendar, TimeZone, Date => JUDate}
 
 import com.workday.warp.common.category.UnitTest
 import com.workday.warp.common.spec.WarpJUnitSpec
@@ -26,8 +26,9 @@ import TablesLike.{TestDefinitionRowLike, TestExecutionRowLike}
   */
 class WarpSlickDslSpec extends WarpJUnitSpec with CorePersistenceAware {
 
+  TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+
   /** Truncates the schema. */
-  @Before
   def truncateSchema(): Unit = {
     Connection.refresh()
     CorePersistenceUtils.truncateSchema()
@@ -42,7 +43,7 @@ class WarpSlickDslSpec extends WarpJUnitSpec with CorePersistenceAware {
 
     val action = TestDefinition.filter(_.methodSignature regexMatch "hello")
 
-    val rows: Seq[TestDefinitionRow] = this.persistenceUtils.runWithRetries(action.result, 5)
+    val rows: Seq[TestDefinitionRow] = this.persistenceUtils.runWithRetries(action.result)
     rows.size shouldEqual 1
     val check: Boolean = rows.exists(t => t.methodSignature.contains("hello") && !t.methodSignature.contains("bye"))
     check shouldEqual true
@@ -56,7 +57,7 @@ class WarpSlickDslSpec extends WarpJUnitSpec with CorePersistenceAware {
     val testDefinition: TestDefinitionRowLike = this.persistenceUtils.findOrCreateTestDefinition(methodSignature3)
     val cast: Rep[String] = testDefinition.methodSignature
     val test: Rep[String] = cast quote()
-    val query1 = this.persistenceUtils.runWithRetries(test.result, 5)
+    val query1 = this.persistenceUtils.runWithRetries(test.result)
 
     val addBackSlash = testDefinition.methodSignature.replaceAll("\'", "\\\\\'")
     val query2 = "\'" + addBackSlash + "\'"
@@ -68,6 +69,7 @@ class WarpSlickDslSpec extends WarpJUnitSpec with CorePersistenceAware {
   @Category(Array(classOf[UnitTest]))
   /** Tests INTERVAL dsl. */
   def betweenInterval(): Unit = {
+    this.truncateSchema()
     this.persistenceUtils.createTestExecution(methodSignature1, new JUDate, 1.0, 10)
     this.persistenceUtils.createTestExecution(methodSignature1, new JUDate, 1.0, 10)
     this.persistenceUtils.createTestExecution(methodSignature1, new JUDate, 1.0, 10)
@@ -111,7 +113,6 @@ class WarpSlickDslSpec extends WarpJUnitSpec with CorePersistenceAware {
     val query: Rep[Long] = date unixTimestamp()
     val result: Long = this.persistenceUtils.runWithRetries(query.result, 5)
 
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
     val cal: Calendar = Calendar.getInstance()
     cal.set(Calendar.HOUR_OF_DAY, 0)
     cal.set(Calendar.SECOND, 0)
@@ -127,7 +128,7 @@ class WarpSlickDslSpec extends WarpJUnitSpec with CorePersistenceAware {
   /** Tests UNIX_TIMESTAMP dsl. */
   def returnUNIXTimeStampNow(): Unit = {
     val query: Rep[Long] = TimeStampExtensions.unixTimestamp()
-    val result: Long = this.persistenceUtils.runWithRetries(query.result, 5)
+    val result: Long = this.persistenceUtils.runWithRetries(query.result)
     val unixTimestamp: Long = Instant.now.getEpochSecond()
     result shouldEqual unixTimestamp +- 2
 
@@ -140,12 +141,12 @@ class WarpSlickDslSpec extends WarpJUnitSpec with CorePersistenceAware {
   this.persistenceUtils.createTestExecution(methodSignature1, new JUDate, 1.0, 10)
     val format: SimpleDateFormat = new SimpleDateFormat("yyyy-MM-dd")
     val cal: Calendar = Calendar.getInstance()
-    val currentDate: String = format.format(cal.getTime())
+    val currentDate: String = format.format(cal.getTime)
 
     // Test years
     val cal1: Calendar = Calendar.getInstance()
     val query1: Rep[String] = TimeStampExtensions.subdate(currentDate, "1 YEAR")
-    val queryYear: String = this.persistenceUtils.runWithRetries(query1.result, 5)
+    val queryYear: String = this.persistenceUtils.runWithRetries(query1.result)
     cal1.add(Calendar.YEAR, -1)
     val resultYear: String = format.format(cal1.getTime)
     resultYear shouldEqual queryYear
@@ -153,7 +154,7 @@ class WarpSlickDslSpec extends WarpJUnitSpec with CorePersistenceAware {
     // Test days
     val cal2: Calendar = Calendar.getInstance()
     val query2: Rep[String] = TimeStampExtensions.subdate(currentDate, "57 DAY")
-    val queryDay: String = this.persistenceUtils.runWithRetries(query2.result, 5)
+    val queryDay: String = this.persistenceUtils.runWithRetries(query2.result)
     cal2.add(Calendar.DATE, -57)
     val resultDay: String = format.format(cal2.getTime)
     resultDay shouldEqual queryDay
@@ -167,7 +168,7 @@ class WarpSlickDslSpec extends WarpJUnitSpec with CorePersistenceAware {
 
     // Test hours
     val query3: Rep[String] = TimeStampExtensions.subdate(currentDate, "-3 HOUR")
-    val queryHour: String = this.persistenceUtils.runWithRetries(query3.result, 5)
+    val queryHour: String = this.persistenceUtils.runWithRetries(query3.result)
     cal3.add(Calendar.HOUR, 3)
     val resultHour: String = hourFormatter.format(cal3.getTime)
     resultHour shouldEqual queryHour
@@ -181,18 +182,18 @@ class WarpSlickDslSpec extends WarpJUnitSpec with CorePersistenceAware {
     this.persistenceUtils.createTestExecution(methodSignature1, new JUDate, 1.0, 10)
     val format: SimpleDateFormat = new SimpleDateFormat("yyyy-MM-dd")
     val cal: Calendar = Calendar.getInstance()
-    val currentDate: String = format.format(cal.getTime())
+    val currentDate: String = format.format(cal.getTime)
 
     val cal2: Calendar = Calendar.getInstance()
     val query: Rep[String] = TimeStampExtensions.subdate(currentDate, 57)
-    val queryDay: String = this.persistenceUtils.runWithRetries(query.result, 5)
+    val queryDay: String = this.persistenceUtils.runWithRetries(query.result)
     cal2.add(Calendar.DATE, -57)
     val resultDay: String = format.format(cal2.getTime)
     resultDay shouldEqual queryDay
 
     val cal3: Calendar = Calendar.getInstance()
     val query2: Rep[String] = TimeStampExtensions.subdate(currentDate, -1)
-    val queryDay2: String = this.persistenceUtils.runWithRetries(query2.result, 5)
+    val queryDay2: String = this.persistenceUtils.runWithRetries(query2.result)
     cal3.add(Calendar.DATE, 1)
     val resultDay2: String = format.format(cal3.getTime)
     resultDay2 shouldEqual queryDay2
@@ -243,12 +244,12 @@ class WarpSlickDslSpec extends WarpJUnitSpec with CorePersistenceAware {
     val date: String = format.format(new java.util.Date())
 
     val testExecution: TestExecutionRowLike = this.persistenceUtils.createTestExecution(methodSignature1, new JUDate, 1.0, 10)
-    val timeStamp: Rep[Timestamp] = testExecution.startTime
-    val query1: Rep[String] = timeStamp date()
-    this.persistenceUtils.runWithRetries(query1.result, 5) shouldEqual date
+    val timeStamp: Rep[sql.Timestamp] = testExecution.startTime
+    val query1: Rep[sql.Date] = timeStamp.date()
+    this.persistenceUtils.runWithRetries(query1.result).toString shouldEqual date
 
-    val query2: Query[Rep[String], String, Seq] = TestExecution.map(t => t.startTime date())
-    this.persistenceUtils.runWithRetries(query2.result, 5).head shouldEqual date
+    val query2: Query[Rep[sql.Date], sql.Date, Seq] = TestExecution.map(_.startTime.date())
+    this.persistenceUtils.runWithRetries(query2.result).head.toString shouldEqual date
 
   }
 
@@ -262,8 +263,8 @@ class WarpSlickDslSpec extends WarpJUnitSpec with CorePersistenceAware {
 
     val testExecution: TestExecutionRowLike = this.persistenceUtils.createTestExecution(methodSignature1, new JUDate, 1.0, 10)
     val queryDate: Rep[String] = format2.format(testExecution.startTime)
-    val query: Rep[String] = queryDate date()
-    this.persistenceUtils.runWithRetries(query.result, 5) shouldEqual currentDate
+    val query: Rep[sql.Date] = queryDate.date()
+    this.persistenceUtils.runWithRetries(query.result).toString shouldEqual currentDate
 
   }
 
@@ -296,7 +297,7 @@ class WarpSlickDslSpec extends WarpJUnitSpec with CorePersistenceAware {
     val testExecution: TestExecutionRowLike = this.persistenceUtils.createTestExecution(methodSignature1, new JUDate, 1.0, 10)
     val timeStamp: Rep[Timestamp] = testExecution.startTime
     val query: Rep[Long] = timeStamp unixTimestamp()
-    val result: Long = this.persistenceUtils.runWithRetries(query.result, 5)
+    val result: Long = this.persistenceUtils.runWithRetries(query.result)
     val unixTimestamp: Long = Instant.now.getEpochSecond()
     result shouldEqual unixTimestamp +- 2
 
@@ -310,13 +311,13 @@ class WarpSlickDslSpec extends WarpJUnitSpec with CorePersistenceAware {
 
     val df1: DecimalFormat = new DecimalFormat("#.#")
     val query1: Rep[Double] = NumberExtension.round(testExecution.responseTime, 1)
-    val result1: Double = this.persistenceUtils.runWithRetries(query1.result, 5)
+    val result1: Double = this.persistenceUtils.runWithRetries(query1.result)
     val roundedNumber1: Double = df1.format(testExecution.responseTime).toDouble
     result1 shouldEqual roundedNumber1
 
     val df2: DecimalFormat = new DecimalFormat("#")
     val query2: Rep[Double] = NumberExtension.round(testExecution.responseTimeRequirement, 0)
-    val result2: Double = this.persistenceUtils.runWithRetries(query2.result, 5)
+    val result2: Double = this.persistenceUtils.runWithRetries(query2.result)
     val roundedNumber2: Double = df2.format(testExecution.responseTimeRequirement).toDouble
     result2 shouldEqual roundedNumber2
 


### PR DESCRIPTION
- date() returns a java.sql.Date instead of a String

a couple of other things:
- i noticed if we have a `Rep[T]`, we can do `x.result.statements` to get the compiled sql statements. this could be useful as another way of checking our extension methods
- got rid of retries in some tests
- we should do something similar for subdate extension methods, they should return something other than string. datetime, I suppose.
- we should also look at some code deduplication. i noticed there are multiple date, subdate methods