### PR TITLE
Scalafix cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
 
 script:
   - docker-compose up -d
-  - ./gradlew -PallScalaVersions copyConfigTemplate compileTestScala checkScalafix reportScoverage checkScoverage --stacktrace
+  - ./gradlew -PallScalaVersions copyConfigTemplate reportScoverage checkScoverage checkScalafix --stacktrace
 
 after_success:
   - ./gradlew coveralls

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We use [scalafix](https://scalacenter.github.io/scalafix/) to automatically refa
 we also need to use semanticdb scala compiler plugin, which harvests and dumps semantic information about the symbols and types in our program.
 Scalafix semantic rules depend on semanticdb compiler output. Scalafix should be run like this:
 ```
-$ ./gradlew clean compileTestScala scalafix compileTestScala
+$ ./gradlew clean scalafix
 ```
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -63,11 +63,6 @@ if (project.hasProperty("teamcity")) {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-configurations {
-    // plugins won't show up as dependencies of the final output
-    scalaCompilerPlugins { transitive = false }
-}
-
 /**
  * When adding new dependencies, we must be mindful of scope, eg api or implementation.
  * The former will be exposed transitively to our consumers compile classpath.
@@ -115,8 +110,6 @@ dependencies {
     runtimeOnly "com.h2database:h2:${versions.h2}"
     runtimeOnly "commons-beanutils:commons-beanutils:${versions.beanUtils}"
     runtimeOnly "mysql:mysql-connector-java:${versions.mysqlConnector}"
-
-    scalaCompilerPlugins "org.scalameta:semanticdb-scalac_${project.scalaVersion}:${versions.semanticDb}"
 }
 
 sourceSets {
@@ -177,9 +170,8 @@ scaladoc {
 
 tasks.withType(ScalaCompile) {
     scalaCompileOptions.additionalParameters = [
-            '-Ywarn-unused',
-            '-Yrangepos',
-            '-Xplugin:' + configurations.scalaCompilerPlugins.asPath
+            // needed for "RemoveUnused" scalafix rule
+            '-Ywarn-unused'
     ]
 }
 

--- a/src/main/scala/com/workday/warp/persistence/Connection.scala
+++ b/src/main/scala/com/workday/warp/persistence/Connection.scala
@@ -20,8 +20,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success, Try}
 
-import scala.util.Random
-
 /**
   * Created by tomas.mccandless on 10/6/16.
   */

--- a/src/main/scala/com/workday/warp/persistence/Connection.scala
+++ b/src/main/scala/com/workday/warp/persistence/Connection.scala
@@ -20,6 +20,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success, Try}
 
+import scala.util.Random
+
 /**
   * Created by tomas.mccandless on 10/6/16.
   */


### PR DESCRIPTION
- a bit of cleanup suggested by @marcelocenerine
- scalafix gradle plugin will autoconfigure semanticdb scalac plugin in a detached gradle configuration, we don't have to do that ourselves
- checkScalafix task has a task dependency on compileTestScala