### PR TITLE
disable maven metadata SHA256/SHA512 checksum publishing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,7 @@ scalaVersions=2.12.10
 # note that devSnapshot and snapshot tasks won't create repo tags
 # see https://github.com/ADTRAN/gradle-scala-multiversion-plugin#advanced-configuration
 runOnceTasks=clean,candidate,final,release,generateGradleLintReport
+
+# prevent publication of SHA256 & SHA512 checksums, which are incompatible with sonatype release repos
+# see https://github.com/gradle/gradle/issues/11308
+systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
this allows us to publish successfully on sonatype