### PR TITLE
Scalafix beta5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,13 +35,14 @@ apply plugin: 'scala'
 apply plugin: 'scalaStyle'
 apply plugin: 'idea'
 apply plugin: 'com.adtran.scala-multiversion-plugin'
-apply plugin: 'io.github.cosmicsilence.scalafix'
 apply plugin: 'org.ajoberstar.grgit'
 apply plugin: 'nebula.dependency-lock'
 apply plugin: 'nebula.gradle-git-scm'
 apply plugin: 'nebula.release'
 apply plugin: 'nebula.maven-resolved-dependencies'
 apply plugin: 'org.scoverage'
+// must be applied after scoverage
+apply plugin: 'io.github.cosmicsilence.scalafix'
 apply plugin: 'com.github.kt3k.coveralls'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
@@ -267,6 +268,11 @@ scoverage {
 
 coveralls {
     coberturaReportPath = "${buildDir}/reports/scoverage/cobertura.xml"
+}
+
+scalafix {
+    excludes = ["**/generated/**"]
+    ignoreSourceSets = ["scoverage"]
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -271,7 +271,7 @@ coveralls {
 }
 
 scalafix {
-    excludes = ["**/generated/**"]
+    excludes = ["**/persistence/model/**"]
     ignoreSourceSets = ["scoverage"]
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,5 @@ runOnceTasks=clean,candidate,final,release,generateGradleLintReport
 # prevent publication of SHA256 & SHA512 checksums, which are incompatible with sonatype release repos
 # see https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true
+
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=2048m

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip

--- a/src/test/scala/com/workday/warp/adapters/BasicSimulation.scala
+++ b/src/test/scala/com/workday/warp/adapters/BasicSimulation.scala
@@ -4,13 +4,15 @@ import com.workday.warp.adapters.gatling.{GatlingJUnitRunner, WarpSimulation}
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import org.junit.runner.RunWith
+import io.gatling.core.structure.ScenarioBuilder
+import io.gatling.http.protocol.HttpProtocolBuilder
 
 @RunWith(classOf[GatlingJUnitRunner])
 class BasicSimulation extends WarpSimulation {
-  val httpConf = http
+  val httpConf: HttpProtocolBuilder = http
     .baseUrl("http://google.com")
 
-  val scn = scenario("Positive Scenario")
+  val scn: ScenarioBuilder = scenario("Positive Scenario")
     .exec(
       http("request_1").get("/")
     )

--- a/versionInfo.gradle
+++ b/versionInfo.gradle
@@ -28,7 +28,7 @@ project.ext.versions = [
     , nebulaRelease: '13.0.0'
     , nebulaPublish: '14.1.1'
     , scalactic: '3.0.+'
-    , scalafix: '0.1.0-beta.2'
+    , scalafix: '0.1.0-beta.5'
     , scalaMultiversion: '1.+'
     , scalatest: '3.0.+'
     , scalaStyle: '1.0.0'


### PR DESCRIPTION
- exclude `scoverage` source set from being scalafixed
- gradle 6.2