### PR TITLE
warp info extension, some java examples

### DIFF
--- a/warp-core/src/main/java/com/workday/warp/junit/WarpInfoProvided.java
+++ b/warp-core/src/main/java/com/workday/warp/junit/WarpInfoProvided.java
@@ -1,0 +1,23 @@
+package com.workday.warp.junit;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Meta-annotation used to make testId and other metadata available to tests.
+ *
+ * This annotation is useful for tests that want to control their own measurement without using any beforeEach or afterEach
+ * hooks.
+ *
+ * Created by tomas.mccandless on 10/23/20.
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(WarpInfoExtension.class)
+@TestTemplate
+public @interface WarpInfoProvided {
+}

--- a/warp-core/src/main/java/com/workday/warp/junit/WarpTest.java
+++ b/warp-core/src/main/java/com/workday/warp/junit/WarpTest.java
@@ -10,6 +10,8 @@ import java.lang.annotation.Target;
 
 /** Meta-annotation used to mark a test for measurement.
  *
+ * Note that we apply TestTemplate annotation here, which is required for our parameter resolvers to be correctly detected.
+ *
  * Created by tomas.mccandless on 6/18/20.
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/warp-core/src/main/scala/com/workday/warp/common/utils/Implicits.scala
+++ b/warp-core/src/main/scala/com/workday/warp/common/utils/Implicits.scala
@@ -300,4 +300,11 @@ object Implicits {
       case Failure(err) => Left(err)
     }
   }
+
+
+
+  implicit class DecoratedOption[T](val maybeT: Option[T]) {
+
+    def toTry: Try[T] = Try(maybeT.get)
+  }
 }

--- a/warp-core/src/main/scala/com/workday/warp/junit/HasTestId.scala
+++ b/warp-core/src/main/scala/com/workday/warp/junit/HasTestId.scala
@@ -2,6 +2,8 @@ package com.workday.warp.junit
 
 import java.lang.reflect.Method
 
+import scala.util.Try
+
 /** Logic for constructing a testId given a testClass and testMethod.
   *
   * Multiple Junit interfaces [[org.junit.jupiter.api.extension.ExtensionContext]] and [[org.junit.jupiter.api.TestInfo]],
@@ -14,9 +16,9 @@ import java.lang.reflect.Method
   */
 trait HasTestId {
 
-  def getTestClass: Option[Class[_]]
+  def getTestClass: Try[Class[_]]
 
-  def getTestMethod: Option[Method]
+  def getTestMethod: Try[Method]
 
   /**
     * Attempts to construct a fully qualified method name.
@@ -25,7 +27,7 @@ trait HasTestId {
     *
     * @return Some fully qualified method name, or [[None]].
     */
-  def getTestId: Option[String] = for {
+  def getTestId: Try[String] = for {
     className: String <- this.getTestClass.map(_.getCanonicalName)
     method: String <- this.getTestMethod.map(_.getName)
   } yield s"$className.$method"

--- a/warp-core/src/main/scala/com/workday/warp/junit/TestIdConverters.scala
+++ b/warp-core/src/main/scala/com/workday/warp/junit/TestIdConverters.scala
@@ -2,10 +2,12 @@ package com.workday.warp.junit
 
 import java.lang.reflect.Method
 
+import com.workday.warp.common.utils.Implicits.DecoratedOption
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtensionContext
 
 import scala.compat.java8.OptionConverters._
+import scala.util.Try
 
 /**
   * Ad-hoc polymorphism for constructing [[HasTestId]].
@@ -15,13 +17,13 @@ import scala.compat.java8.OptionConverters._
 object TestIdConverters {
 
   implicit def testInfoHasTestId(info: TestInfo): HasTestId = new HasTestId {
-    override def getTestClass: Option[Class[_]] = info.getTestClass.asScala
-    override def getTestMethod: Option[Method] = info.getTestMethod.asScala
+    override def getTestClass: Try[Class[_]] = info.getTestClass.asScala.toTry
+    override def getTestMethod: Try[Method] = info.getTestMethod.asScala.toTry
   }
 
 
   implicit def extensionContextHasTestId(context: ExtensionContext): HasTestId = new HasTestId {
-    override def getTestClass: Option[Class[_]] = context.getTestClass.asScala
-    override def getTestMethod: Option[Method] = context.getTestMethod.asScala
+    override def getTestClass: Try[Class[_]] = context.getTestClass.asScala.toTry
+    override def getTestMethod: Try[Method] = context.getTestMethod.asScala.toTry
   }
 }

--- a/warp-core/src/main/scala/com/workday/warp/junit/WarpInfo.scala
+++ b/warp-core/src/main/scala/com/workday/warp/junit/WarpInfo.scala
@@ -3,10 +3,8 @@ package com.workday.warp.junit
 /** Used with JUnit parameter resolvers to make test iteration metadata available to running test methods.
   *
   * @param testId test identifier we use to record results. Typically fully qualified method name.
-  * @param currentRepetition current repetition of the corresponding test method.
-  * @param repetitionType type of the current test invocation.
-  * @param numWarmups number of unmeasured warmup invocations for this test.
-  * @param numTrials number of measured trial invocations for this test.
+  * @param maybeMeasurementInfo [[Option]] containing [[WarpMeasurementInfo]].
+  *                            Will be none if we are running a test with [[WarpInfoProvided]]
   *
   * Created by tomas.mccandless on 6/18/20.
   */
@@ -19,7 +17,15 @@ case class WarpInfo(testId: String, maybeMeasurementInfo: Option[WarpMeasurement
   def currentRepLimit: Int = maybeMeasurementInfo.map(_.currentRepLimit).getOrElse(1)
 }
 
+/** Used with JUnit parameter resolvers to make test measurement metadata available to running test methods.
+  *
+  * @param currentRepetition current repetition of the corresponding test method.
+  * @param repetitionType type of the current test invocation.
+  * @param numWarmups number of unmeasured warmup invocations for this test.
+  * @param numTrials number of measured trial invocations for this test.
+  */
 case class WarpMeasurementInfo(currentRepetition: Int, repetitionType: RepetitionType, numWarmups: Int, numTrials: Int) {
+
   /** Total number of repetitions of the corresponding [[WarpTest]] method. (warmups + trials) */
   def totalRepetitions: Int = numWarmups + numTrials
 

--- a/warp-core/src/main/scala/com/workday/warp/junit/WarpInfo.scala
+++ b/warp-core/src/main/scala/com/workday/warp/junit/WarpInfo.scala
@@ -2,24 +2,15 @@ package com.workday.warp.junit
 
 /** Used with JUnit parameter resolvers to make test iteration metadata available to running test methods.
   *
+  * @param testId test identifier we use to record results. Typically fully qualified method name.
+  * @param currentRepetition current repetition of the corresponding test method.
+  * @param repetitionType type of the current test invocation.
+  * @param numWarmups number of unmeasured warmup invocations for this test.
+  * @param numTrials number of measured trial invocations for this test.
+  *
   * Created by tomas.mccandless on 6/18/20.
   */
-trait WarpInfoLike {
-
-  /** Test ID we use to record results. Typically fully qualified method name. */
-  def testId: String
-
-  /** Current repetition of the corresponding [[WarpTest]] method. */
-  def currentRepetition: Int
-
-  /** Type of the current test invocation. Warmup, or trial. */
-  def repetitionType: RepetitionType
-
-  /** Number of unmeasured warmup invocations for this test. */
-  def numWarmups: Int
-
-  /** Number of measured trial invocations for this test. */
-  def numTrials: Int
+case class WarpInfo(testId: String, currentRepetition: Int, repetitionType: RepetitionType, numWarmups: Int, numTrials: Int) {
 
   /** Total number of repetitions of the corresponding [[WarpTest]] method. (warmups + trials) */
   def totalRepetitions: Int = numWarmups + numTrials
@@ -31,13 +22,7 @@ trait WarpInfoLike {
   }
 }
 
+
 trait HasWarpInfo {
-  def warpInfo: WarpInfoLike
+  def warpInfo: WarpInfo
 }
-
-
-case class WarpInfo(testId: String,
-                    currentRepetition: Int,
-                    repetitionType: RepetitionType,
-                    numWarmups: Int,
-                    numTrials: Int) extends WarpInfoLike

--- a/warp-core/src/main/scala/com/workday/warp/junit/WarpInfo.scala
+++ b/warp-core/src/main/scala/com/workday/warp/junit/WarpInfo.scala
@@ -10,8 +10,16 @@ package com.workday.warp.junit
   *
   * Created by tomas.mccandless on 6/18/20.
   */
-case class WarpInfo(testId: String, currentRepetition: Int, repetitionType: RepetitionType, numWarmups: Int, numTrials: Int) {
+case class WarpInfo(testId: String, maybeMeasurementInfo: Option[WarpMeasurementInfo] = None) {
 
+  /** Total number of repetitions of the corresponding [[WarpTest]] method. (warmups + trials) */
+  def totalRepetitions: Int = maybeMeasurementInfo.map(_.totalRepetitions).getOrElse(1)
+
+  /** Repetition limit for the current repetition type. Number of warmups or measured trials. */
+  def currentRepLimit: Int = maybeMeasurementInfo.map(_.currentRepLimit).getOrElse(1)
+}
+
+case class WarpMeasurementInfo(currentRepetition: Int, repetitionType: RepetitionType, numWarmups: Int, numTrials: Int) {
   /** Total number of repetitions of the corresponding [[WarpTest]] method. (warmups + trials) */
   def totalRepetitions: Int = numWarmups + numTrials
 

--- a/warp-core/src/main/scala/com/workday/warp/junit/WarpInfoExtension.scala
+++ b/warp-core/src/main/scala/com/workday/warp/junit/WarpInfoExtension.scala
@@ -1,0 +1,49 @@
+package com.workday.warp.junit
+
+import java.util.stream.Stream
+
+import com.workday.warp.junit.TestIdConverters.extensionContextHasTestId
+import org.junit.jupiter.api.extension.{ExtensionContext, TestTemplateInvocationContext, TestTemplateInvocationContextProvider}
+import org.junit.platform.commons.util.AnnotationUtils
+
+
+/**
+  * A simple provider of invocation contexts that is solely meant to provide access to [[WarpInfo]], including testId.
+  *
+  * Note that we don't modify display name, or register a [[MeasurementExtension]] at all here.
+  *
+  * This extension should be used when your tests only need access to their names, and you want more fine-grained control
+  * over the ordering between extensions, eg if a [[MeasurementExtension]] before and after hooks would conflict with
+  * any other before/after hooks you may have.
+  *
+  * Created by tomas.mccandless on 10/23/20.
+  */
+trait WarpInfoExtensionLike extends TestTemplateInvocationContextProvider with TestIdSupport {
+
+  /**
+    * We only support test templates that are annotated with [[WarpInfoProvided]].
+    *
+    * @param context [[ExtensionContext]] containing test method and display name.
+    * @return whether the test method is annotated with [[WarpTest]].
+    */
+  override def supportsTestTemplate(context: ExtensionContext): Boolean = {
+    AnnotationUtils.isAnnotated(context.getTestMethod, classOf[WarpInfoProvided])
+  }
+
+
+  /**
+    * Provides a Stream of contexts corresponding to each invocation.
+    *
+    * In this case, we don't insert extra invocations, we only provide [[WarpInfo]] to a singular invocation.
+    *
+    * @param context [[ExtensionContext]] containing test method and display name.
+    * @return a singleton [[Stream]] of invocation context.
+    */
+  override def provideTestTemplateInvocationContexts(context: ExtensionContext): Stream[TestTemplateInvocationContext] = {
+    val testId: String = context.getTestId.get
+    val info: WarpInfo = WarpInfo(testId, 1, Warmup, 1, 0)
+    Stream.of(Seq(WarpInfoInvocationContext(context.getDisplayName, info)): _*)
+  }
+}
+
+class WarpInfoExtension extends WarpInfoExtensionLike

--- a/warp-core/src/main/scala/com/workday/warp/junit/WarpInfoExtension.scala
+++ b/warp-core/src/main/scala/com/workday/warp/junit/WarpInfoExtension.scala
@@ -18,7 +18,7 @@ import org.junit.platform.commons.util.AnnotationUtils
   *
   * Created by tomas.mccandless on 10/23/20.
   */
-trait WarpInfoExtensionLike extends TestTemplateInvocationContextProvider with TestIdSupport {
+trait WarpInfoExtensionLike extends TestTemplateInvocationContextProvider {
 
   /**
     * We only support test templates that are annotated with [[WarpInfoProvided]].
@@ -40,8 +40,8 @@ trait WarpInfoExtensionLike extends TestTemplateInvocationContextProvider with T
     * @return a singleton [[Stream]] of invocation context.
     */
   override def provideTestTemplateInvocationContexts(context: ExtensionContext): Stream[TestTemplateInvocationContext] = {
-    val testId: String = context.getTestId.get
-    val info: WarpInfo = WarpInfo(testId, 1, Warmup, 1, 0)
+    // TODO finalize behavior here. throw an exception? fall back on another testId?
+    val info: WarpInfo = WarpInfo(context.getTestId.get)
     Stream.of(Seq(WarpInfoInvocationContext(context.getDisplayName, info)): _*)
   }
 }

--- a/warp-core/src/main/scala/com/workday/warp/junit/WarpInfoInvocationContext.scala
+++ b/warp-core/src/main/scala/com/workday/warp/junit/WarpInfoInvocationContext.scala
@@ -1,0 +1,15 @@
+package com.workday.warp.junit
+
+import org.junit.jupiter.api.extension.Extension
+
+/**
+  * Created by tomas.mccandless on 10/23/20.
+  */
+trait WarpInfoInvocationContextLike extends WarpTestInvocationContextLike {
+
+  override def getDisplayName(invocationIndex: Int): String = s"$plainDisplayName [$invocationIndex]"
+}
+
+case class WarpInfoInvocationContext( plainDisplayName: String,
+                                      warpInfo: WarpInfo,
+                                      additionalExtensions: List[Extension] = Nil) extends WarpInfoInvocationContextLike

--- a/warp-core/src/main/scala/com/workday/warp/junit/WarpInfoParameterResolver.scala
+++ b/warp-core/src/main/scala/com/workday/warp/junit/WarpInfoParameterResolver.scala
@@ -9,13 +9,13 @@ import org.junit.jupiter.api.extension.{ExtensionContext, ParameterContext, Para
 trait WarpInfoParameterResolverLike extends ParameterResolver with HasWarpInfo {
 
   override def supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean = {
-    parameterContext.getParameter.getType == classOf[WarpInfoLike]
+    parameterContext.getParameter.getType == classOf[WarpInfo]
   }
 
-  override def resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): WarpInfoLike = {
+  override def resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): WarpInfo = {
     this.warpInfo
   }
 }
 
 
-case class WarpInfoParameterResolver(warpInfo: WarpInfoLike) extends WarpInfoParameterResolverLike
+case class WarpInfoParameterResolver(warpInfo: WarpInfo) extends WarpInfoParameterResolverLike

--- a/warp-core/src/main/scala/com/workday/warp/junit/WarpTestExtension.scala
+++ b/warp-core/src/main/scala/com/workday/warp/junit/WarpTestExtension.scala
@@ -17,7 +17,7 @@ import scala.collection.JavaConversions._
   *
   * Created by tomas.mccandless on 6/18/20.
  */
-trait WarpTestExtensionLike extends TestTemplateInvocationContextProvider with TestIdSupport {
+trait WarpTestExtensionLike extends TestTemplateInvocationContextProvider {
 
   /**
     * We only support test templates that are annotated with [[WarpTest]].
@@ -50,12 +50,12 @@ trait WarpTestExtensionLike extends TestTemplateInvocationContextProvider with T
     val testId: String = context.getTestId.get
 
     val warmups: Seq[WarpTestInvocationContext] = (1 to numWarmups).map { w =>
-      val warmupInfo: WarpInfo = WarpInfo(testId, w, Warmup, numWarmups, numTrials)
+      val warmupInfo: WarpInfo = WarpInfo(testId, Option(WarpMeasurementInfo(w, Warmup, numWarmups, numTrials)))
       WarpTestInvocationContext(displayName, warmupInfo)
     }
     // tweak our display name for warmups vs trials
     val trials: Seq[WarpTestInvocationContext] = (1 to numTrials).map { t =>
-      val trialInfo: WarpInfo = WarpInfo(testId, t, Trial, numWarmups, numTrials)
+      val trialInfo: WarpInfo = WarpInfo(testId, Option(WarpMeasurementInfo(t, Trial, numWarmups, numTrials)))
       WarpTestInvocationContext(
       displayName,
       trialInfo,

--- a/warp-core/src/main/scala/com/workday/warp/junit/WarpTestExtension.scala
+++ b/warp-core/src/main/scala/com/workday/warp/junit/WarpTestExtension.scala
@@ -9,7 +9,7 @@ import org.junit.platform.commons.util.{AnnotationUtils, Preconditions}
 
 import scala.collection.JavaConversions._
 
-/** TestTemplate for running WarpTests.
+/** TestTemplate for running and measuring WarpTests.
   *
   * We emit a stream of invocation contexts corresponding to warmups and measured trials based on [[WarpTest]] annotation.
   *
@@ -50,12 +50,12 @@ trait WarpTestExtensionLike extends TestTemplateInvocationContextProvider with T
     val testId: String = context.getTestId.get
 
     val warmups: Seq[WarpTestInvocationContext] = (1 to numWarmups).map { w =>
-      val warmupInfo: WarpInfoLike = WarpInfo(testId, w, Warmup, numWarmups, numTrials)
+      val warmupInfo: WarpInfo = WarpInfo(testId, w, Warmup, numWarmups, numTrials)
       WarpTestInvocationContext(displayName, warmupInfo)
     }
     // tweak our display name for warmups vs trials
     val trials: Seq[WarpTestInvocationContext] = (1 to numTrials).map { t =>
-      val trialInfo: WarpInfoLike = WarpInfo(testId, t, Trial, numWarmups, numTrials)
+      val trialInfo: WarpInfo = WarpInfo(testId, t, Trial, numWarmups, numTrials)
       WarpTestInvocationContext(
       displayName,
       trialInfo,

--- a/warp-core/src/main/scala/com/workday/warp/junit/WarpTestInvocationContext.scala
+++ b/warp-core/src/main/scala/com/workday/warp/junit/WarpTestInvocationContext.scala
@@ -12,7 +12,6 @@ import scala.collection.JavaConversions._
   * Created by tomas.mccandless on 6/18/20.
   */
 trait WarpTestInvocationContextLike extends TestTemplateInvocationContext with HasWarpInfo {
-  import WarpTestInvocationContextLike._
 
   // plain vanilla method display name
   def plainDisplayName: String
@@ -26,11 +25,7 @@ trait WarpTestInvocationContextLike extends TestTemplateInvocationContext with H
    * @return A test invocation display name including current repetition info.
    */
   override def getDisplayName(invocationIndex: Int): String = {
-    displayNamePattern
-      .replace(plainDisplayNameToken, this.plainDisplayName)
-      .replace(currentRepToken, this.warpInfo.currentRepetition.toString)
-      .replace(totalRepsToken, this.warpInfo.currentRepLimit.toString)
-      .replace(repTypeToken, this.warpInfo.repetitionType.name)
+    s"$plainDisplayName [${warpInfo.repetitionType.name} ${warpInfo.currentRepetition} of ${warpInfo.currentRepLimit}]"
   }
 
   /**
@@ -41,27 +36,10 @@ trait WarpTestInvocationContextLike extends TestTemplateInvocationContext with H
     * @return additional JUnit extensions for this test invocation.
     */
   override def getAdditionalExtensions: util.List[Extension] = {
-    (WarpInfoParameterResolver(this.warpInfo) :: additionalExtensions)
+    WarpInfoParameterResolver(this.warpInfo) :: additionalExtensions
   }
 }
 
-object WarpTestInvocationContextLike {
-  /** Placeholder for the plain [[org.junit.jupiter.api.TestInfo]] display name of a [[WarpTest]] method. */
-  lazy val plainDisplayNameToken = "{plainDisplayName}"
-
-  /** Placeholder for the current repetition count of a [[WarpTest]] method. */
-  lazy val currentRepToken = "{currentRepetition}"
-
-  /** Placeholder for the total number of repetitions of a [[WarpTest]] method. */
-  lazy val totalRepsToken = "{totalRepetitions}"
-
-  /** Placeholder for the type of run of a [[WarpTest]] method, eg "warmup" or "trial". */
-  lazy val repTypeToken = "{repetitionType}"
-
-  /** Display name pattern for a [[WarpTest]]. */
-  lazy val displayNamePattern: String = s"$plainDisplayNameToken [$repTypeToken $currentRepToken of $totalRepsToken]"
-}
-
 case class WarpTestInvocationContext(plainDisplayName: String,
-                                     warpInfo: WarpInfoLike,
+                                     warpInfo: WarpInfo,
                                      additionalExtensions: List[Extension] = List.empty) extends WarpTestInvocationContextLike

--- a/warp-core/src/main/scala/com/workday/warp/junit/WarpTestInvocationContext.scala
+++ b/warp-core/src/main/scala/com/workday/warp/junit/WarpTestInvocationContext.scala
@@ -25,7 +25,10 @@ trait WarpTestInvocationContextLike extends TestTemplateInvocationContext with H
    * @return A test invocation display name including current repetition info.
    */
   override def getDisplayName(invocationIndex: Int): String = {
-    s"$plainDisplayName [${warpInfo.repetitionType.name} ${warpInfo.currentRepetition} of ${warpInfo.currentRepLimit}]"
+    val repInfo: String = warpInfo.maybeMeasurementInfo
+      .map(info => s" [${info.repetitionType.name} ${info.currentRepetition} of ${info.currentRepLimit}]")
+      .getOrElse("")
+    s"$plainDisplayName$repInfo"
   }
 
   /**

--- a/warp-core/src/test/java/com/workday/warp/examples/ExampleTest.java
+++ b/warp-core/src/test/java/com/workday/warp/examples/ExampleTest.java
@@ -35,7 +35,7 @@ public class ExampleTest {
 
 
     /** Annotated WarpTests can also use the same parameter provider mechanism to pass WarpInfo. */
-    @WarpTest()
+    @WarpTest
     public void measuredWithInfo(final WarpInfo info) {
         Assert.assertTrue(info.testId().equals("com.workday.warp.examples.ExampleTest.measuredWithInfo"));
     }

--- a/warp-core/src/test/java/com/workday/warp/examples/ExampleTest.java
+++ b/warp-core/src/test/java/com/workday/warp/examples/ExampleTest.java
@@ -1,0 +1,42 @@
+package com.workday.warp.examples;
+
+import com.workday.warp.junit.WarpInfo;
+import com.workday.warp.junit.WarpInfoProvided;
+import com.workday.warp.junit.WarpTest;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.pmw.tinylog.Logger;
+
+/**
+ * Created by tomas.mccandless on 10/23/20.
+ */
+public class ExampleTest {
+
+    /** A plain vanilla junit test with no extensions. */
+    @Test
+    public void vanilla() {
+        Logger.trace("only plain junit infra");
+    }
+
+
+    /** An example of using WarpInfoExtension only for the purpose of getting access to a testId. */
+    @WarpInfoProvided
+    public void run(final WarpInfo info) {
+        Logger.trace("we are only being executed");
+        Assert.assertTrue(info.testId().equals("com.workday.warp.examples.ExampleTest.run"));
+    }
+
+
+    /** A test that will be invoked a total of 6 times, 2 unmeasured warmups and 4 measured trials. */
+    @WarpTest(warmups = 1, trials = 2)
+    public void measured() {
+        Logger.trace("we are being measured");
+    }
+
+
+    /** Annotated WarpTests can also use the same parameter provider mechanism to pass WarpInfo. */
+    @WarpTest()
+    public void measuredWithInfo(final WarpInfo info) {
+        Assert.assertTrue(info.testId().equals("com.workday.warp.examples.ExampleTest.measuredWithInfo"));
+    }
+}

--- a/warp-core/src/test/scala/com/workday/warp/common/heaphistogram/HeapHistogramSpec.scala
+++ b/warp-core/src/test/scala/com/workday/warp/common/heaphistogram/HeapHistogramSpec.scala
@@ -34,9 +34,8 @@ class HeapHistogramSpec extends WarpJUnitSpec with HistogramIoLike with HasRando
     */
   @UnitTest
   def getPidSpec(): Unit = {
-    val pid = HistogramIoLike.pid
-
-    pid should not be 0
+    val pid: String = HistogramIoLike.pid
+    pid should not be "0"
   }
 
   /**

--- a/warp-core/src/test/scala/com/workday/warp/junit/WarpInfoSpec.scala
+++ b/warp-core/src/test/scala/com/workday/warp/junit/WarpInfoSpec.scala
@@ -5,7 +5,7 @@ import com.workday.warp.common.spec.WarpJUnitSpec
 /**
   * Created by tomas.mccandless on 6/24/20.
   */
-class WarpInfoLikeSpec extends WarpJUnitSpec {
+class WarpInfoSpec extends WarpJUnitSpec {
 
   /**
     * An example of requesting test invocation metadata indirectly via [[WarpInfoParameterResolverLike]]
@@ -13,7 +13,7 @@ class WarpInfoLikeSpec extends WarpJUnitSpec {
     * @param info info about test iterations.
     */
   @WarpTest(trials = 3)
-  def hasInfo(info: WarpInfoLike): Unit = {
+  def hasInfo(info: WarpInfo): Unit = {
     info.totalRepetitions should be (3)
   }
 }


### PR DESCRIPTION
- new junit extension `WarpInfoExtension` only provides access to `WarpInfo` (test id), does not insert any measurement calls
- some other simplifications, removed `WarpInfoLike` trait in favor of only having `WarpInfo` case class.