### PR TITLE
new DI bindings for persistence

### DIFF
--- a/warp-core/src/main/scala/com/workday/warp/inject/WarpGuicer.scala
+++ b/warp-core/src/main/scala/com/workday/warp/inject/WarpGuicer.scala
@@ -8,7 +8,8 @@ import com.workday.warp.config.{PropertyEntry, WarpPropertyLike}
 import com.workday.warp.TestIdImplicits._
 import com.workday.warp.controllers.AbstractMeasurementCollectionController
 import com.workday.warp.inject.modules.{DefaultWarpModule, HasWarpBindings}
-import com.workday.warp.persistence.Tag
+import com.workday.warp.persistence.influxdb.InfluxDBClient
+import com.workday.warp.persistence.{PersistenceAware, Tag}
 import org.junit.jupiter.api.TestInfo
 import org.pmw.tinylog.Logger
 
@@ -123,4 +124,10 @@ object WarpGuicer {
 
   /** @return object with warp configuration [[com.workday.warp.config.PropertyEntry]]. */
   def getProperty: WarpPropertyLike = this.baseInjector.getInstance(classOf[WarpPropertyLike])
+
+  /** @return a persistence class [[PersistenceAware]]. */
+  def getPersistence: PersistenceAware = this.baseInjector.getInstance(classOf[PersistenceAware])
+
+  /** @return an influxdb client [[InfluxDBClient]]. */
+  def getInfluxDb: InfluxDBClient = this.baseInjector.getInstance(classOf[InfluxDBClient])
 }

--- a/warp-core/src/main/scala/com/workday/warp/inject/modules/DefaultWarpModule.scala
+++ b/warp-core/src/main/scala/com/workday/warp/inject/modules/DefaultWarpModule.scala
@@ -5,7 +5,8 @@ import com.workday.warp.TestId
 import com.workday.warp.config.{CoreWarpProperty, WarpPropertyLike}
 import com.workday.warp.controllers.{AbstractMeasurementCollectionController, DefaultMeasurementCollectionController}
 import com.workday.warp.logger.WriterConfig
-import com.workday.warp.persistence.Tag
+import com.workday.warp.persistence.influxdb.InfluxDBClient
+import com.workday.warp.persistence.{CorePersistenceUtils, PersistenceAware, Tag}
 
 /**
   * Defines default dependency injection bindings for [[DefaultMeasurementCollectionController]] based on the values
@@ -31,4 +32,10 @@ class DefaultWarpModule(override val testId: TestId,
 
   /** @return a [[Seq]] of additional log [[Writer]] that should be enabled. */
   @Provides override def getExtraWriters: Seq[WriterConfig] = Seq.empty
+
+  /** @return a persistence class [[PersistenceAware]]. */
+  @Provides override def getPersistence: PersistenceAware = CorePersistenceUtils
+
+  /** @return a client for InfluxDb. */
+  @Provides override def getInfluxDb: InfluxDBClient = new InfluxDBClient { }
 }

--- a/warp-core/src/main/scala/com/workday/warp/inject/modules/HasWarpBindings.scala
+++ b/warp-core/src/main/scala/com/workday/warp/inject/modules/HasWarpBindings.scala
@@ -5,7 +5,8 @@ import com.workday.warp.TestId
 import com.workday.warp.config.WarpPropertyLike
 import com.workday.warp.controllers.AbstractMeasurementCollectionController
 import com.workday.warp.logger.WriterConfig
-import com.workday.warp.persistence.Tag
+import com.workday.warp.persistence.influxdb.InfluxDBClient
+import com.workday.warp.persistence.{PersistenceAware, Tag}
 
 /**
   * This trait should be mixed in and overridden with values that can be passed to create instances of
@@ -29,4 +30,10 @@ trait HasWarpBindings {
 
   /** @return a [[Seq]] of additional log [[Writer]] that should be enabled. */
   @Provides def getExtraWriters: Seq[WriterConfig]
+
+  /** @return a persistence class [[PersistenceAware]]. */
+  @Provides def getPersistence: PersistenceAware
+
+  /** @return a client for InfluxDb. */
+  @Provides def getInfluxDb: InfluxDBClient
 }

--- a/warp-core/src/main/scala/com/workday/warp/persistence/CorePersistenceAware.scala
+++ b/warp-core/src/main/scala/com/workday/warp/persistence/CorePersistenceAware.scala
@@ -2,6 +2,7 @@ package com.workday.warp.persistence
 
 import java.sql.Timestamp
 import java.time.Instant
+
 import com.workday.warp.TestId
 import com.workday.warp.config.CoreWarpProperty._
 import com.workday.warp.config.WarpPropertyManager

--- a/warp-core/src/test/scala/com/workday/warp/inject/WarpGuicerSpec.scala
+++ b/warp-core/src/test/scala/com/workday/warp/inject/WarpGuicerSpec.scala
@@ -6,6 +6,7 @@ import com.workday.warp.config.{CoreWarpProperty, WarpPropertyLike}
 import com.workday.warp.junit.{UnitTest, WarpJUnitSpec}
 import com.workday.warp.TestIdImplicits.string2TestId
 import com.workday.warp.controllers.{AbstractMeasurementCollectionController, DefaultMeasurementCollectionController}
+import com.workday.warp.persistence.{CorePersistenceUtils, PersistenceAware}
 
 /**
   *
@@ -44,6 +45,14 @@ class WarpGuicerSpec extends WarpJUnitSpec {
   def injectCoreWarpProperty(): Unit = {
     WarpGuicer.getProperty.getClass should be (CoreWarpProperty.getClass)
     WarpGuicer.getInstance(classOf[WarpPropertyLike]).getClass should be (CoreWarpProperty.getClass)
+  }
+
+
+  /** Checks that we bind the correct runtime implementation for persistence. */
+  @UnitTest
+  def injectPersistence(): Unit = {
+    WarpGuicer.getPersistence.getClass should be (CorePersistenceUtils.getClass)
+    WarpGuicer.getInstance(classOf[PersistenceAware]).getClass should be (CorePersistenceUtils.getClass)
   }
 
 


### PR DESCRIPTION
- found a bug where `WarpMatchers` is using a hard-coded schema instead of going through dependency injection