### PR TITLE
truncate spike filter test execution tag

### DIFF
--- a/warp-core/src/main/scala/com/workday/warp/arbiters/ArbiterLike.scala
+++ b/warp-core/src/main/scala/com/workday/warp/arbiters/ArbiterLike.scala
@@ -47,7 +47,7 @@ trait ArbiterLike extends PersistenceAware with CanReadHistory {
     // tag this execution with failure reason
     // "failure-{class}", "message"
     maybeFailure.foreach { f =>
-      val msg: String = Option(f.getMessage).getOrElse("null")
+      val msg: String = Option(f.getMessage).getOrElse("null").take(255)
       this.persistenceUtils.recordTestExecutionTag(testExecution.idTestExecution, tagName, msg)
     }
 


### PR DESCRIPTION
tag column is a `VARCHAR(255)`, make sure the value we are trying to write fits in that length.