### PR TITLE
support around recording functional test failures

### DIFF
--- a/warp-core/src/main/scala/com/workday/warp/arbiters/CanReadHistory.scala
+++ b/warp-core/src/main/scala/com/workday/warp/arbiters/CanReadHistory.scala
@@ -30,11 +30,12 @@ trait CanReadHistory extends CorePersistenceAware {
     * @return training data to be used for voting algorithm.
     */
     // TODO we don't need to include testId here, excludeIdTestExecution is sufficient to read the data we are interested in
-  def responseTimes(testId: String, excludeIdTestExecution: Int,
-                    startDateLowerBound: LocalDate = CanReadHistory.DEFAULT_EPOCH_DAY,
-                    useSlidingWindow: Boolean = WARP_ARBITER_SLIDING_WINDOW.value.toBoolean,
-                    slidingWindowSize: Int = WARP_ARBITER_SLIDING_WINDOW_SIZE.value.toInt): Iterable[Double] = {
-    val responseTimes: Iterable[Double] = this.allResponseTimes(testId, excludeIdTestExecution, startDateLowerBound)
+  def successfulResponseTimes(testId: String,
+                              excludeIdTestExecution: Int,
+                              startDateLowerBound: LocalDate = CanReadHistory.DEFAULT_EPOCH_DAY,
+                              useSlidingWindow: Boolean = WARP_ARBITER_SLIDING_WINDOW.value.toBoolean,
+                              slidingWindowSize: Int = WARP_ARBITER_SLIDING_WINDOW_SIZE.value.toInt): Iterable[Double] = {
+    val responseTimes: Iterable[Double] = this.allSuccessfulResponseTimes(testId, excludeIdTestExecution, startDateLowerBound)
     // check if we should use a sliding window, or return all historical data
     if (useSlidingWindow) responseTimes takeRight slidingWindowSize
     else responseTimes
@@ -43,6 +44,8 @@ trait CanReadHistory extends CorePersistenceAware {
 
   /**
     * Checks whether the last `alertOnNth - 1` executions failed with a message from the same arbiter.
+    *
+    * We don't need to filter out failed test executions here, just looking at tags is enough.
     *
     * @param testExecution
     * @param tagName
@@ -72,10 +75,10 @@ trait CanReadHistory extends CorePersistenceAware {
     * @param excludeIdTestExecution id of the [[com.workday.warp.persistence.Tables.TestExecution]] to exclude from the results.
     * @return training data to be used for voting algorithm.
     */
-  def allResponseTimes(testId: String,
-                       excludeIdTestExecution: Int,
-                       startDateLowerBound: LocalDate = CanReadHistory.DEFAULT_EPOCH_DAY): Iterable[Double] = {
-    this.persistenceUtils.getResponseTimes(CoreIdentifier(methodSignature = testId), excludeIdTestExecution, startDateLowerBound)
+  def allSuccessfulResponseTimes(testId: String,
+                                 excludeIdTestExecution: Int,
+                                 startDateLowerBound: LocalDate = CanReadHistory.DEFAULT_EPOCH_DAY): Iterable[Double] = {
+    this.persistenceUtils.getSuccessfulResponseTimes(CoreIdentifier(methodSignature = testId), excludeIdTestExecution, startDateLowerBound)
   }
 }
 

--- a/warp-core/src/main/scala/com/workday/warp/arbiters/PercentageDegradationArbiter.scala
+++ b/warp-core/src/main/scala/com/workday/warp/arbiters/PercentageDegradationArbiter.scala
@@ -11,6 +11,8 @@ import com.workday.warp.logger.WarpLogging
   * Arbiter that checks whether the response time for this test was within an acceptable percentage of the historical
   * arithmetic mean.
   *
+  * Should only consider successful test history.
+  *
   * Created by tomas.mccandless on 5/13/16.
   */
 class PercentageDegradationArbiter extends CanReadHistory with ArbiterLike with WarpLogging {

--- a/warp-core/src/main/scala/com/workday/warp/arbiters/PercentageDegradationArbiter.scala
+++ b/warp-core/src/main/scala/com/workday/warp/arbiters/PercentageDegradationArbiter.scala
@@ -26,7 +26,7 @@ class PercentageDegradationArbiter extends CanReadHistory with ArbiterLike with 
     */
   override def vote[T: TestExecutionRowLikeType](ballot: Ballot, testExecution: T): Option[Throwable] = {
     val minimumHistoricalData: Int = WARP_ARBITER_SLIDING_WINDOW_SIZE.value.toInt
-    this.vote(this.responseTimes(ballot.testId.id, testExecution.idTestExecution), ballot, testExecution, minimumHistoricalData)
+    this.vote(this.successfulResponseTimes(ballot.testId.id, testExecution.idTestExecution), ballot, testExecution, minimumHistoricalData)
   }
 
 

--- a/warp-core/src/main/scala/com/workday/warp/arbiters/RobustPcaArbiter.scala
+++ b/warp-core/src/main/scala/com/workday/warp/arbiters/RobustPcaArbiter.scala
@@ -30,7 +30,7 @@ class RobustPcaArbiter(val lPenalty: Double = WARP_ANOMALY_RPCA_L_PENALTY.value.
     // it is actually the last entry (another test could have been written to the database, thus causing the order to be
     // incorrect.
     // we need to ensure the response time for this test execution is the final entry in this list.
-    val rawResponseTimes: Iterable[Double] = this.responseTimes(
+    val rawResponseTimes: Iterable[Double] = this.successfulResponseTimes(
       ballot.testId.id,
       testExecution.idTestExecution
     ) ++ List(testExecution.responseTime)

--- a/warp-core/src/main/scala/com/workday/warp/arbiters/RobustPcaArbiter.scala
+++ b/warp-core/src/main/scala/com/workday/warp/arbiters/RobustPcaArbiter.scala
@@ -13,6 +13,8 @@ import com.workday.warp.persistence.Tables._
   * https://statweb.stanford.edu/~candes/papers/RobustPCA.pdf (Candes, 2009)
   * http://arxiv.org/pdf/1001.2363v1.pdf (Zhou, 2010)
   *
+  * Should only consider successful test history.
+  *
   * Created by tomas.mccandless on 2/18/16.
   */
 class RobustPcaArbiter(val lPenalty: Double = WARP_ANOMALY_RPCA_L_PENALTY.value.toDouble,

--- a/warp-core/src/main/scala/com/workday/warp/arbiters/SmartNumberArbiter.scala
+++ b/warp-core/src/main/scala/com/workday/warp/arbiters/SmartNumberArbiter.scala
@@ -18,6 +18,8 @@ import scala.util.{Failure, Success, Try}
 /**
   * Uses bisection method with [[RobustPca]] to automatically determine a static threshold.
   *
+  * Should only consider successful test history.
+  *
   * Created by tomas.mccandless on 9/13/16.
   */
 class SmartNumberArbiter(val lPenalty: Double = WARP_ANOMALY_RPCA_L_PENALTY.value.toDouble,

--- a/warp-core/src/main/scala/com/workday/warp/arbiters/SmartNumberArbiter.scala
+++ b/warp-core/src/main/scala/com/workday/warp/arbiters/SmartNumberArbiter.scala
@@ -69,7 +69,7 @@ class SmartNumberArbiter(val lPenalty: Double = WARP_ANOMALY_RPCA_L_PENALTY.valu
     }
     else {
       // we don't care about today's response time for this
-      val rawResponseTimes: Iterable[Double] = this.responseTimes(ballot.testId.id, testExecution.idTestExecution,
+      val rawResponseTimes: Iterable[Double] = this.successfulResponseTimes(ballot.testId.id, testExecution.idTestExecution,
         startDateLowerBound, useSlidingWindow, slidingWindowSize)
       val threshold: Duration = this.smartNumber(rawResponseTimes).seconds
       val responseTime: Duration = TimeUtils.toNanos(testExecution.responseTime, TimeUnit.SECONDS).nanoseconds

--- a/warp-core/src/main/scala/com/workday/warp/arbiters/ZScoreArbiter.scala
+++ b/warp-core/src/main/scala/com/workday/warp/arbiters/ZScoreArbiter.scala
@@ -26,7 +26,7 @@ class ZScoreArbiter extends CanReadHistory with ArbiterLike with WarpLogging {
     */
   override def vote[T: TestExecutionRowLikeType](ballot: Ballot, testExecution: T): Option[Throwable] = {
     this.vote(
-      this.responseTimes(ballot.testId.id, testExecution.idTestExecution),
+      this.successfulResponseTimes(ballot.testId.id, testExecution.idTestExecution),
       ballot,
       testExecution,
       WARP_ARBITER_MINIMUM_N.value.toInt

--- a/warp-core/src/main/scala/com/workday/warp/arbiters/ZScoreArbiter.scala
+++ b/warp-core/src/main/scala/com/workday/warp/arbiters/ZScoreArbiter.scala
@@ -15,6 +15,8 @@ import com.workday.warp.logger.WarpLogging
   * Constructs a [[NormalDistribution]] using the historical arithmetic mean and standard deviation, and evaluates
   * the cumulative probability of the measured response time.
   *
+  * Should only consider successful test history.
+  *
   * Created by tomas.mccandless on 1/25/16.
   */
 class ZScoreArbiter extends CanReadHistory with ArbiterLike with WarpLogging {

--- a/warp-core/src/main/scala/com/workday/warp/controllers/AbstractMeasurementCollectionController.scala
+++ b/warp-core/src/main/scala/com/workday/warp/controllers/AbstractMeasurementCollectionController.scala
@@ -254,6 +254,7 @@ abstract class AbstractMeasurementCollectionController(val testId: TestId, val t
         this.timeStarted,
         responseTime.doubleSeconds,
         threshold.doubleSeconds,
+        passed = true,
         trial.maybeDocumentation
       )
     )

--- a/warp-core/src/main/scala/com/workday/warp/persistence/AbstractQueries.scala
+++ b/warp-core/src/main/scala/com/workday/warp/persistence/AbstractQueries.scala
@@ -106,6 +106,7 @@ trait AbstractQueries {
   // TODO we can probably get rid of many of these overloadings
   def responseTimesQuery[I: IdentifierType](identifier: I): DBIO[Seq[Double]]
 
+  def successfulResponseTimesQuery[I: IdentifierType](identifier: I): DBIO[Seq[Double]]
 
   /**
     * Creates a [[DBIO]] for reading historical response times. The response time for the [[TestExecutionRowLike]]
@@ -117,6 +118,7 @@ trait AbstractQueries {
     */
   def responseTimesQuery[I: IdentifierType](identifier: I, excludeIdTestExecution: Int): DBIO[Seq[Double]]
 
+  def successfulResponseTimesQuery[I: IdentifierType](identifier: I, excludeIdTestExecution: Int): DBIO[Seq[Double]]
 
   /**
     * Creates a [[DBIO]] for reading historical response times. The response time for the [[TestExecutionRowLike]]
@@ -131,6 +133,9 @@ trait AbstractQueries {
                                             excludeIdTestExecution: Int,
                                             startDateLowerBound: LocalDate): DBIO[Seq[Double]]
 
+  def successfulResponseTimesQuery[I: IdentifierType](identifier: I,
+                                                      excludeIdTestExecution: Int,
+                                                      startDateLowerBound: LocalDate): DBIO[Seq[Double]]
 
   /**
     * Creates a [[DBIO]] for reading historical Measurement rows.

--- a/warp-core/src/main/scala/com/workday/warp/persistence/AbstractQueries.scala
+++ b/warp-core/src/main/scala/com/workday/warp/persistence/AbstractQueries.scala
@@ -106,6 +106,12 @@ trait AbstractQueries {
   // TODO we can probably get rid of many of these overloadings
   def responseTimesQuery[I: IdentifierType](identifier: I): DBIO[Seq[Double]]
 
+  /**
+    * Creates a [[DBIO]] for reading only successful historical response times.
+    *
+    * @param identifier [[IdentifierType]] containing the identifying parameters of the [[TestExecutionLike]]
+    * @return a [[DBIO]] for reading only successful historical response times.
+    */
   def successfulResponseTimesQuery[I: IdentifierType](identifier: I): DBIO[Seq[Double]]
 
   /**
@@ -118,6 +124,14 @@ trait AbstractQueries {
     */
   def responseTimesQuery[I: IdentifierType](identifier: I, excludeIdTestExecution: Int): DBIO[Seq[Double]]
 
+  /**
+    * Creates a [[DBIO]] for reading only successful historical response times. The response time for the [[TestExecutionRowLike]]
+    * with `excludeIdTestExecution` will be excluded from the results.
+    *
+    * @param identifier [[IdentifierType]] containing the identifying parameters of the [[TestExecutionLike]]
+    * @param excludeIdTestExecution idTestExecution to exclude from results.
+    * @return a [[DBIO]] for reading only successful historical response times.
+    */
   def successfulResponseTimesQuery[I: IdentifierType](identifier: I, excludeIdTestExecution: Int): DBIO[Seq[Double]]
 
   /**
@@ -133,6 +147,15 @@ trait AbstractQueries {
                                             excludeIdTestExecution: Int,
                                             startDateLowerBound: LocalDate): DBIO[Seq[Double]]
 
+  /**
+    * Creates a [[DBIO]] for reading only successful historical response times. The response time for the [[TestExecutionRowLike]]
+    * with `excludeIdTestExecution` and a startTime timestamp before 'startDateCutoff' will be excluded from the results.
+    *
+    * @param identifier [[IdentifierType]] containing the identifying parameters of the [[TestExecutionLike]]
+    * @param excludeIdTestExecution idTestExecution to exclude from results.
+    * @param startDateLowerBound only include cases that start after/on this lower bound date.
+    * @return a [[DBIO]] for reading only successful historical response times.
+    */
   def successfulResponseTimesQuery[I: IdentifierType](identifier: I,
                                                       excludeIdTestExecution: Int,
                                                       startDateLowerBound: LocalDate): DBIO[Seq[Double]]

--- a/warp-core/src/main/scala/com/workday/warp/persistence/CorePersistenceAware.scala
+++ b/warp-core/src/main/scala/com/workday/warp/persistence/CorePersistenceAware.scala
@@ -133,6 +133,7 @@ trait CorePersistenceAware extends PersistenceAware with WarpLogging {
                                      timeStarted: Instant,
                                      responseTime: Double,
                                      maxResponseTime: Double,
+                                     passed: Boolean = true,
                                      maybeDocs: Option[String] = None): TablesLike.TestExecutionRowLike = {
       if (responseTime == 0.0) {
         throw new IllegalArgumentException("Zero Time recorded for this measurement, check your adapter implementation.")
@@ -146,7 +147,7 @@ trait CorePersistenceAware extends PersistenceAware with WarpLogging {
         Tables.nullId,
         idTestDefinition = testDefinition.idTestDefinition,
         idBuild = buildInfo.idBuild,
-        passed = true,
+        passed = passed,
         responseTime = responseTime,
         responseTimeRequirement = maxResponseTime,
         startTime = Timestamp from timeStarted,

--- a/warp-core/src/main/scala/com/workday/warp/persistence/CorePersistenceAware.scala
+++ b/warp-core/src/main/scala/com/workday/warp/persistence/CorePersistenceAware.scala
@@ -126,6 +126,7 @@ trait CorePersistenceAware extends PersistenceAware with WarpLogging {
       * @param timeStarted time the measured test was started.
       * @param responseTime observed duration of the measured test (seconds).
       * @param maxResponseTime maximum allowable response time set on the measured test (seconds).
+      * @param passed a boolean indicating whether the test functionally passed.
       * @param maybeDocs containing documentation for the [[TestExecutionRow]]
       * @return a [[TestExecutionRowLike]] with the given parameters.
       */

--- a/warp-core/src/main/scala/com/workday/warp/persistence/CoreQueries.scala
+++ b/warp-core/src/main/scala/com/workday/warp/persistence/CoreQueries.scala
@@ -181,6 +181,12 @@ trait CoreQueries extends AbstractQueries {
   }
 
 
+  /**
+    * Creates a [[DBIO]] for reading only successful historical response times.
+    *
+    * @param identifier a [[CoreIdentifier]] containing the methodSignature to query TestExecutions
+    * @return a [[DBIO]] for reading only successful historical response times.
+    */
   override def successfulResponseTimesQuery[I: IdentifierType](identifier: I): DBIO[Seq[Double]] = {
     for {
       maybeRow <- this.testExecutionsQuery(identifier).map(_.filter(_.passed))
@@ -206,6 +212,15 @@ trait CoreQueries extends AbstractQueries {
     } yield result
   }
 
+
+  /**
+    * Creates a [[DBIO]] for reading only successful historical response times.
+    * The response time for the [[TestExecutionRow]] with `excludeIdTestExecution` will be excluded from the results.
+    *
+    * @param identifier a [[CoreIdentifier]] containing the methodSignature to query TestExecutions
+    * @param excludeIdTestExecution idTestExecution to exclude from results.
+    * @return a [[DBIO]] for reading only successful historical response times.
+    */
   override def successfulResponseTimesQuery[I: IdentifierType](identifier: I, excludeIdTestExecution: Int): DBIO[Seq[Double]] = {
     for {
       maybeRow <- this.testExecutionsQuery(identifier)
@@ -240,6 +255,17 @@ trait CoreQueries extends AbstractQueries {
   }
 
 
+  /**
+    * Creates a [[DBIO]] for reading only successful historical response times.
+    *
+    * The response time for the [[TestExecutionRow]] with `excludeIdTestExecution`
+    * and a startTime timestamp before 'startDateCutoff' will be excluded from the results.
+    *
+    * @param identifier [[CoreIdentifier]] containing the methodSignature of the [[TestExecutionLike]]
+    * @param excludeIdTestExecution idTestExecution to exclude from results.
+    * @param startDateLowerBound only include cases that start after/on this lower bound date.
+    * @return a [[DBIO]] for reading only successful historical response times.
+    */
   override def successfulResponseTimesQuery[I: IdentifierType](identifier: I,
                                                                excludeIdTestExecution: Int,
                                                                startDateLowerBound: LocalDate): DBIO[Seq[Double]] = {

--- a/warp-core/src/main/scala/com/workday/warp/persistence/PersistenceAware.scala
+++ b/warp-core/src/main/scala/com/workday/warp/persistence/PersistenceAware.scala
@@ -316,6 +316,12 @@ trait PersistenceAware extends WarpLogging {
     }
 
 
+    /**
+      * Gets only successful historical response times (seconds) for running test identified by `identifier`.
+      *
+      * @param identifier [[IdentifierType]] containing the identifying parameters of the measured test.
+      * @return a [[List]] of only successful historical response times.
+      */
     def getSuccessfulResponseTimes[I: IdentifierType](identifier: I): List[Double] = {
       this.synchronously(this.successfulResponseTimesQuery(identifier)).toList
     }
@@ -333,7 +339,14 @@ trait PersistenceAware extends WarpLogging {
       this.synchronously(this.responseTimesQuery(identifier, excludeIdTestExecution)).toList
     }
 
-
+    /**
+      * Gets only successful historical response times (seconds) for running `testId` and `confidenceLevel`. The response time for the
+      * [[TestExecutionRowLike]] with `excludeIdTestExecution` will be omitted.
+      *
+      * @param identifier [[IdentifierType]] containing the identifying parameters of the measured test.
+      * @param excludeIdTestExecution idTestExecution to exclude from results.
+      * @return a [[List]] of only successful historical response times.
+      */
     def getSuccessfulResponseTimes[I: IdentifierType](identifier: I, excludeIdTestExecution: Int): List[Double] = {
       this.synchronously(this.successfulResponseTimesQuery(identifier, excludeIdTestExecution)).toList
     }
@@ -353,6 +366,15 @@ trait PersistenceAware extends WarpLogging {
     }
 
 
+    /**
+      * Gets only succcesful historical response times (seconds) for running `testId` and `confidenceLevel`. The response time for the
+      * [[TestExecutionRowLike]] with `excludeIdTestExecution` and before 'startDateCutoff' will be omitted.
+      *
+      * @param identifier [[IdentifierType]] containing the identifying parameters of the measured test.
+      * @param excludeIdTestExecution idTestExecution to exclude from results.
+      * @param startDateLowerBound ignore all results before this date.
+      * @return a [[List]] of only successful historical response times.
+      */
     def getSuccessfulResponseTimes[I: IdentifierType](identifier: I,
                                                       excludeIdTestExecution: Int,
                                                       startDateLowerBound: LocalDate): List[Double] = {

--- a/warp-core/src/main/scala/com/workday/warp/persistence/PersistenceAware.scala
+++ b/warp-core/src/main/scala/com/workday/warp/persistence/PersistenceAware.scala
@@ -110,6 +110,7 @@ trait PersistenceAware extends WarpLogging {
       * @param timeStarted time the measured test was started.
       * @param responseTime observed duration of the measured test (seconds).
       * @param maxResponseTime maximum allowable response time set on the measured test (seconds).
+      * @param passed whether the test functionally passed. Generally speaking we don't want record functionally failures.
       * @param maybeDocs optional documentation for the [[TestExecutionRowLike]].
       * @return a [[TestExecutionRowLike]] with the given parameters.
       */
@@ -117,6 +118,7 @@ trait PersistenceAware extends WarpLogging {
                             timeStarted: Instant,
                             responseTime: Double,
                             maxResponseTime: Double,
+                            passed: Boolean = true,
                             maybeDocs: Option[String] = None): TestExecutionRowLike
 
     /**
@@ -314,6 +316,11 @@ trait PersistenceAware extends WarpLogging {
     }
 
 
+    def getSuccessfulResponseTimes[I: IdentifierType](identifier: I): List[Double] = {
+      this.synchronously(this.successfulResponseTimesQuery(identifier)).toList
+    }
+
+
     /**
       * Gets historical response times (seconds) for running `testId` and `confidenceLevel`. The response time for the
       * [[TestExecutionRowLike]] with `excludeIdTestExecution` will be omitted.
@@ -324,6 +331,11 @@ trait PersistenceAware extends WarpLogging {
       */
     def getResponseTimes[I: IdentifierType](identifier: I, excludeIdTestExecution: Int): List[Double] = {
       this.synchronously(this.responseTimesQuery(identifier, excludeIdTestExecution)).toList
+    }
+
+
+    def getSuccessfulResponseTimes[I: IdentifierType](identifier: I, excludeIdTestExecution: Int): List[Double] = {
+      this.synchronously(this.successfulResponseTimesQuery(identifier, excludeIdTestExecution)).toList
     }
 
 
@@ -338,6 +350,13 @@ trait PersistenceAware extends WarpLogging {
       */
     def getResponseTimes[I: IdentifierType](identifier: I, excludeIdTestExecution: Int, startDateLowerBound: LocalDate): List[Double] = {
       this.synchronously(this.responseTimesQuery(identifier, excludeIdTestExecution, startDateLowerBound)).toList
+    }
+
+
+    def getSuccessfulResponseTimes[I: IdentifierType](identifier: I,
+                                                      excludeIdTestExecution: Int,
+                                                      startDateLowerBound: LocalDate): List[Double] = {
+      this.synchronously(this.successfulResponseTimesQuery(identifier, excludeIdTestExecution, startDateLowerBound)).toList
     }
 
 

--- a/warp-core/src/main/scala/com/workday/warp/persistence/PersistenceAware.scala
+++ b/warp-core/src/main/scala/com/workday/warp/persistence/PersistenceAware.scala
@@ -110,7 +110,7 @@ trait PersistenceAware extends WarpLogging {
       * @param timeStarted time the measured test was started.
       * @param responseTime observed duration of the measured test (seconds).
       * @param maxResponseTime maximum allowable response time set on the measured test (seconds).
-      * @param passed whether the test functionally passed. Generally speaking we don't want record functionally failures.
+      * @param passed whether the test functionally passed. Generally speaking we don't want to record functionally failures.
       * @param maybeDocs optional documentation for the [[TestExecutionRowLike]].
       * @return a [[TestExecutionRowLike]] with the given parameters.
       */


### PR DESCRIPTION
- add `passed=true` as a method parameter for recording test results
- arbiters that need historical data should filter out failures from db
- didn't modify MeasurementCollectionController behavior, I don't think that is needed (yet, maybe not at all)